### PR TITLE
test(contracts): add cross-repo continuity guard tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    name: Compile & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Compile contracts
+        run: npm run compile
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Lint
+        run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,9 @@ ignition/deployments/chain-31337
 
 # ElizaOS: Ignore local storage files
 *.eliza/
+
+# Local tmux/dmux session files
+.tmux-devfleet/
+.dmux/
+.dmux-hooks/
+.dmux-session/

--- a/abi-diff.md
+++ b/abi-diff.md
@@ -1,0 +1,65 @@
+# ABI Diff Report
+
+**Date:** 2026-04-25  
+**Branch:** tests-tokenized  
+**Compiler:** solc 0.8.24 (evmVersion: paris)
+
+## Sources compared
+
+| Source | Path |
+|--------|------|
+| Compiled artifact | `artifacts/contracts/EVMAIAgent.sol/EVMAIAgent.json` |
+| Compiled artifact | `artifacts/contracts/EVMAIAgentEscrow.sol/EVMAIAgentEscrow.json` |
+| dApp ABI | `../sense-ai-dapp/src/lib/abi/EVMAIAgent.json` |
+| dApp ABI | `../sense-ai-dapp/src/lib/abi/EVMAIAgentEscrow.json` |
+| Subgraph ABI | `../sense-ai-subgraph/abis/EVMAIAgent.json` |
+| Subgraph ABI | `../sense-ai-subgraph/abis/EVMAIAgentEscrow.json` |
+
+## Result: NO DIFFERENCES FOUND
+
+### EVMAIAgent
+
+**Events (17):** all identical across compiled / dApp / subgraph
+
+| Event | Status |
+|-------|--------|
+| AgentEscrowUpdated | OK |
+| AgentJobSubmitted | OK |
+| AnswerMessageAdded | OK |
+| BranchRequested | OK |
+| ConversationAdded | OK |
+| ConversationBranched | OK |
+| ConversationMetadataUpdated | OK |
+| Initialized | OK |
+| MetadataUpdateRequested | OK |
+| OracleUpdated | OK |
+| OwnershipTransferred | OK |
+| PromptCancelled | OK |
+| PromptMessageAdded | OK |
+| **PromptSubmitted** | **OK** — param[3] `answerMessageId` (non-indexed) matches in all three |
+| RegenerationRequested | OK |
+| SearchIndexDeltaAdded | OK |
+| Upgraded | OK |
+
+**Functions:** all identical across compiled / dApp / subgraph
+
+### EVMAIAgentEscrow
+
+**Events:** all identical across compiled / dApp / subgraph
+
+**Functions:** all identical across compiled / dApp / subgraph
+
+## Key invariant verified
+
+`PromptSubmitted` event parameter order is consistent in all three ABIs:
+
+```
+[0] address indexed  user
+[1] uint256 indexed  conversationId
+[2] uint256 indexed  promptMessageId
+[3] uint256          answerMessageId  ← universal linking key, NON-INDEXED
+[4] bytes            encryptedPayload
+[5] bytes            roflEncryptedKey
+```
+
+`answerMessageId` at index 3 is confirmed non-indexed in the compiled artifact, the dApp ABI, and the subgraph ABI.

--- a/test/CidBundle.fieldOrder.test.js
+++ b/test/CidBundle.fieldOrder.test.js
@@ -1,0 +1,306 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("Suite 4 — CidBundle Field Order and Event Emission", function () {
+  const domain = "example.com";
+  const INITIAL_ALLOWANCE = ethers.parseEther("100");
+  const PROMPT_FEE = ethers.parseEther("10");
+  const CANCELLATION_FEE = ethers.parseEther("1");
+  const METADATA_FEE = ethers.parseEther("0.5");
+  const BRANCH_FEE = ethers.parseEther("2");
+
+  const CID_A = "QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const CID_B = "QmBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const CID_C = "QmCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+  const CID_D = "QmDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+  const CID_E = "QmEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+
+  async function deployFixture() {
+    const [deployer, user, oracle, treasury] = await ethers.getSigners();
+
+    const MockTokenFactory = await ethers.getContractFactory("MockAbleToken");
+    const token = await MockTokenFactory.deploy();
+    await token.waitForDeployment();
+    await token.mint(user.address, INITIAL_ALLOWANCE);
+
+    const EVMAIAgent = await ethers.getContractFactory("EVMAIAgent");
+    const aiAgent = await upgrades.deployProxy(
+      EVMAIAgent,
+      [domain, oracle.address, deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await aiAgent.waitForDeployment();
+
+    const EVMAIAgentEscrow = await ethers.getContractFactory("EVMAIAgentEscrow");
+    const escrow = await upgrades.deployProxy(
+      EVMAIAgentEscrow,
+      [
+        await token.getAddress(),
+        await aiAgent.getAddress(),
+        treasury.address,
+        deployer.address,
+        PROMPT_FEE,
+        CANCELLATION_FEE,
+        METADATA_FEE,
+        BRANCH_FEE,
+      ],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await escrow.waitForDeployment();
+
+    await aiAgent.connect(deployer).setAgentEscrow(await escrow.getAddress());
+    await token.connect(user).approve(await escrow.getAddress(), INITIAL_ALLOWANCE);
+
+    return { aiAgent, escrow, token, deployer, user, oracle, treasury };
+  }
+
+  async function initiateAndCapture(escrow, aiAgent, user) {
+    const expiresAt = (await time.latest()) + 7200;
+    const limitTx = await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+    await limitTx.wait();
+
+    const tx = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+    const receipt = await tx.wait();
+
+    const escrowIface = escrow.interface;
+    const agentIface = aiAgent.interface;
+
+    const paymentEscrowedTopic = escrowIface.getEvent("PaymentEscrowed").topicHash;
+    const promptSubmittedTopic = agentIface.getEvent("PromptSubmitted").topicHash;
+
+    const escrowLog = receipt.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+    const answerMessageId = escrowIface.parseLog(escrowLog).args[0];
+
+    const agentLog = receipt.logs.find((l) => l.topics[0] === promptSubmittedTopic);
+    const promptMessageId = agentIface.parseLog(agentLog).args[2];
+
+    return { answerMessageId, promptMessageId };
+  }
+
+  describe("CidBundle struct field order", function () {
+    it("CidBundle fields are: conversationCID, metadataCID, promptMessageCID, answerMessageCID, searchDeltaCID", async function () {
+      const { aiAgent } = await loadFixture(deployFixture);
+
+      const submitAnswerFragment = aiAgent.interface.getFunction("submitAnswer");
+      const cidBundleParam = submitAnswerFragment.inputs[2];
+
+      expect(cidBundleParam.name).to.equal("_cids");
+      expect(cidBundleParam.components).to.have.length(5);
+
+      expect(cidBundleParam.components[0].name).to.equal("conversationCID");
+      expect(cidBundleParam.components[1].name).to.equal("metadataCID");
+      expect(cidBundleParam.components[2].name).to.equal("promptMessageCID");
+      expect(cidBundleParam.components[3].name).to.equal("answerMessageCID");
+      expect(cidBundleParam.components[4].name).to.equal("searchDeltaCID");
+    });
+  });
+
+  describe("Event emission per CID field", function () {
+    it("all five non-empty CIDs emit their respective events", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const { answerMessageId, promptMessageId } = await initiateAndCapture(escrow, aiAgent, user);
+
+      const cidBundle = {
+        conversationCID: CID_A,
+        metadataCID: CID_B,
+        promptMessageCID: CID_C,
+        answerMessageCID: CID_D,
+        searchDeltaCID: CID_E,
+      };
+
+      await expect(
+        aiAgent.connect(oracle).submitAnswer(promptMessageId, answerMessageId, cidBundle),
+      )
+        .to.emit(aiAgent, "ConversationAdded")
+        .and.to.emit(aiAgent, "PromptMessageAdded")
+        .and.to.emit(aiAgent, "AnswerMessageAdded")
+        .and.to.emit(aiAgent, "SearchIndexDeltaAdded");
+    });
+
+    it("empty conversationCID and metadataCID suppress ConversationAdded (subsequent prompt in same conversation)", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const { answerMessageId, promptMessageId } = await initiateAndCapture(escrow, aiAgent, user);
+
+      const cidBundle = {
+        conversationCID: "",
+        metadataCID: "",
+        promptMessageCID: CID_C,
+        answerMessageCID: CID_D,
+        searchDeltaCID: CID_E,
+      };
+
+      const tx = await aiAgent
+        .connect(oracle)
+        .submitAnswer(promptMessageId, answerMessageId, cidBundle);
+      const receipt = await tx.wait();
+
+      const agentIface = aiAgent.interface;
+      const conversationAddedTopic = agentIface.getEvent("ConversationAdded").topicHash;
+      const conversationLog = receipt.logs.find((l) => l.topics[0] === conversationAddedTopic);
+      expect(conversationLog).to.be.undefined;
+
+      const promptMessageAddedTopic = agentIface.getEvent("PromptMessageAdded").topicHash;
+      expect(receipt.logs.find((l) => l.topics[0] === promptMessageAddedTopic)).to.not.be.undefined;
+
+      const answerMessageAddedTopic = agentIface.getEvent("AnswerMessageAdded").topicHash;
+      expect(receipt.logs.find((l) => l.topics[0] === answerMessageAddedTopic)).to.not.be.undefined;
+    });
+
+    it("empty searchDeltaCID emits SearchIndexDeltaAdded with empty string when promptMessageCID is non-empty", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const { answerMessageId, promptMessageId } = await initiateAndCapture(escrow, aiAgent, user);
+
+      const cidBundle = {
+        conversationCID: CID_A,
+        metadataCID: CID_B,
+        promptMessageCID: CID_C,
+        answerMessageCID: CID_D,
+        searchDeltaCID: "",
+      };
+
+      const tx = await aiAgent
+        .connect(oracle)
+        .submitAnswer(promptMessageId, answerMessageId, cidBundle);
+      const receipt = await tx.wait();
+
+      // SearchIndexDeltaAdded is emitted whenever promptMessageCID is non-empty;
+      // an empty searchDeltaCID produces the event with an empty string value.
+      const agentIface = aiAgent.interface;
+      const searchDeltaTopic = agentIface.getEvent("SearchIndexDeltaAdded").topicHash;
+      const searchLog = receipt.logs.find((l) => l.topics[0] === searchDeltaTopic);
+      expect(searchLog).to.not.be.undefined;
+      const parsed = agentIface.parseLog(searchLog);
+      expect(parsed.args[1]).to.equal("", "searchDeltaCID arg should be empty string");
+    });
+
+    it("empty promptMessageCID suppresses PromptMessageAdded", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const { answerMessageId, promptMessageId } = await initiateAndCapture(escrow, aiAgent, user);
+
+      const cidBundle = {
+        conversationCID: CID_A,
+        metadataCID: CID_B,
+        promptMessageCID: "",
+        answerMessageCID: CID_D,
+        searchDeltaCID: CID_E,
+      };
+
+      const tx = await aiAgent
+        .connect(oracle)
+        .submitAnswer(promptMessageId, answerMessageId, cidBundle);
+      const receipt = await tx.wait();
+
+      const agentIface = aiAgent.interface;
+      const promptMessageAddedTopic = agentIface.getEvent("PromptMessageAdded").topicHash;
+      expect(receipt.logs.find((l) => l.topics[0] === promptMessageAddedTopic)).to.be.undefined;
+    });
+
+    it("empty answerMessageCID reverts with AnswerCIDRequired (answer CID is mandatory)", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const { answerMessageId, promptMessageId } = await initiateAndCapture(escrow, aiAgent, user);
+
+      const cidBundle = {
+        conversationCID: CID_A,
+        metadataCID: CID_B,
+        promptMessageCID: CID_C,
+        answerMessageCID: "",
+        searchDeltaCID: CID_E,
+      };
+
+      await expect(
+        aiAgent.connect(oracle).submitAnswer(promptMessageId, answerMessageId, cidBundle),
+      ).to.be.revertedWithCustomError(aiAgent, "AnswerCIDRequired");
+    });
+  });
+
+  describe("ConversationAdded only on first prompt of a conversation", function () {
+    it("ConversationAdded fires on first prompt; does not fire on subsequent prompt with empty conversationCID", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 7200;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      // First prompt: new conversation (conversationId = 0 → auto-assigned)
+      const tx1 = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+      const receipt1 = await tx1.wait();
+
+      const escrowIface = escrow.interface;
+      const agentIface = aiAgent.interface;
+
+      const escrowLog1 = receipt1.logs.find(
+        (l) => l.topics[0] === escrowIface.getEvent("PaymentEscrowed").topicHash,
+      );
+      const answerMessageId1 = escrowIface.parseLog(escrowLog1).args[0];
+
+      const agentLog1 = receipt1.logs.find(
+        (l) => l.topics[0] === agentIface.getEvent("PromptSubmitted").topicHash,
+      );
+      const promptMessageId1 = agentIface.parseLog(agentLog1).args[2];
+      const conversationId1 = agentIface.parseLog(agentLog1).args[1];
+
+      const firstBundle = {
+        conversationCID: CID_A,
+        metadataCID: CID_B,
+        promptMessageCID: CID_C,
+        answerMessageCID: CID_D,
+        searchDeltaCID: CID_E,
+      };
+
+      const submitTx1 = await aiAgent
+        .connect(oracle)
+        .submitAnswer(promptMessageId1, answerMessageId1, firstBundle);
+      const submitReceipt1 = await submitTx1.wait();
+      const conversationAddedTopic = agentIface.getEvent("ConversationAdded").topicHash;
+      expect(submitReceipt1.logs.find((l) => l.topics[0] === conversationAddedTopic)).to.not.be
+        .undefined;
+
+      // Second prompt: same conversation, no conversationCID
+      const tx2 = await escrow.connect(user).initiatePrompt(conversationId1, "0x", "0x");
+      const receipt2 = await tx2.wait();
+
+      const escrowLog2 = receipt2.logs.find(
+        (l) => l.topics[0] === escrowIface.getEvent("PaymentEscrowed").topicHash,
+      );
+      const answerMessageId2 = escrowIface.parseLog(escrowLog2).args[0];
+
+      const agentLog2 = receipt2.logs.find(
+        (l) => l.topics[0] === agentIface.getEvent("PromptSubmitted").topicHash,
+      );
+      const promptMessageId2 = agentIface.parseLog(agentLog2).args[2];
+
+      const subsequentBundle = {
+        conversationCID: "",
+        metadataCID: "",
+        promptMessageCID: CID_C,
+        answerMessageCID: CID_D,
+        searchDeltaCID: CID_E,
+      };
+
+      const submitTx2 = await aiAgent
+        .connect(oracle)
+        .submitAnswer(promptMessageId2, answerMessageId2, subsequentBundle);
+      const submitReceipt2 = await submitTx2.wait();
+      expect(submitReceipt2.logs.find((l) => l.topics[0] === conversationAddedTopic)).to.be
+        .undefined;
+    });
+  });
+
+  describe("Only oracle can call submitAnswer", function () {
+    it("reverts when a non-oracle account calls submitAnswer", async function () {
+      const { aiAgent, escrow, user, deployer } = await loadFixture(deployFixture);
+      const { answerMessageId, promptMessageId } = await initiateAndCapture(escrow, aiAgent, user);
+
+      const cidBundle = {
+        conversationCID: CID_A,
+        metadataCID: CID_B,
+        promptMessageCID: CID_C,
+        answerMessageCID: CID_D,
+        searchDeltaCID: CID_E,
+      };
+
+      await expect(
+        aiAgent.connect(user).submitAnswer(promptMessageId, answerMessageId, cidBundle),
+      ).to.be.revertedWithCustomError(aiAgent, "UnauthorizedOracle");
+    });
+  });
+});

--- a/test/PromptSubmitted.params.test.js
+++ b/test/PromptSubmitted.params.test.js
@@ -4,6 +4,11 @@ const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
 const path = require("path");
 const fs = require("fs");
 
+// Golden-file ABI snapshots committed under test/fixtures/.
+// These represent the dApp and subgraph ABIs at the last verified sync point.
+// If the contract ABI changes without updating these files, the tests below fail.
+const FIXTURE_DIR = path.resolve(__dirname, "fixtures");
+
 describe("Suite 1 — PromptSubmitted Event Parameter Order", function () {
   const domain = "example.com";
 
@@ -111,19 +116,9 @@ describe("Suite 1 — PromptSubmitted Event Parameter Order", function () {
     });
   });
 
-  describe("ABI sync: compiled artifact vs dApp ABI vs subgraph ABI", function () {
-    before(function () {
-      const sentinel = path.resolve(
-        __dirname,
-        "../../../../../sense-ai-dapp/src/lib/abi/EVMAIAgent.json",
-      );
-      if (!fs.existsSync(sentinel)) {
-        this.skip(); // sibling repos not checked out (CI single-repo environment)
-      }
-    });
-
-    function loadExternalAbi(relPath) {
-      const abs = path.resolve(__dirname, "../../../../../", relPath);
+  describe("ABI sync: compiled artifact vs golden-file snapshots (dApp, subgraph)", function () {
+    function loadFixtureAbi(filename) {
+      const abs = path.resolve(FIXTURE_DIR, filename);
       const raw = JSON.parse(fs.readFileSync(abs, "utf8"));
       return Array.isArray(raw) ? raw : raw.abi;
     }
@@ -140,58 +135,56 @@ describe("Suite 1 — PromptSubmitted Event Parameter Order", function () {
       }));
     }
 
-    it("dApp ABI PromptSubmitted matches compiled ABI", async function () {
+    it("dApp golden-file PromptSubmitted matches compiled ABI", async function () {
       const { aiAgent } = await loadFixture(deployFixture);
       const compiledFragment = aiAgent.interface.getEvent("PromptSubmitted");
       const compiledInputs = normalisedInputs(compiledFragment);
 
-      const dappAbi = loadExternalAbi("sense-ai-dapp/src/lib/abi/EVMAIAgent.json");
+      const dappAbi = loadFixtureAbi("dapp-EVMAIAgent.json");
       const dappFragment = extractEventFragment(dappAbi, "PromptSubmitted");
-      expect(dappFragment, "dApp ABI missing PromptSubmitted event").to.not.be.undefined;
+      expect(dappFragment, "dApp golden file missing PromptSubmitted event").to.not.be.undefined;
 
-      const dappInputs = normalisedInputs(dappFragment);
-      expect(dappInputs).to.deep.equal(compiledInputs);
+      expect(normalisedInputs(dappFragment)).to.deep.equal(compiledInputs);
     });
 
-    it("subgraph ABI PromptSubmitted matches compiled ABI", async function () {
+    it("subgraph golden-file PromptSubmitted matches compiled ABI", async function () {
       const { aiAgent } = await loadFixture(deployFixture);
       const compiledFragment = aiAgent.interface.getEvent("PromptSubmitted");
       const compiledInputs = normalisedInputs(compiledFragment);
 
-      const subgraphAbi = loadExternalAbi("sense-ai-subgraph/abis/EVMAIAgent.json");
+      const subgraphAbi = loadFixtureAbi("subgraph-EVMAIAgent.json");
       const subgraphFragment = extractEventFragment(subgraphAbi, "PromptSubmitted");
-      expect(subgraphFragment, "Subgraph ABI missing PromptSubmitted event").to.not.be.undefined;
+      expect(subgraphFragment, "Subgraph golden file missing PromptSubmitted event").to.not.be
+        .undefined;
 
-      const subgraphInputs = normalisedInputs(subgraphFragment);
-      expect(subgraphInputs).to.deep.equal(compiledInputs);
+      expect(normalisedInputs(subgraphFragment)).to.deep.equal(compiledInputs);
     });
 
-    it("answerMessageId is param[3] (non-indexed) in all three ABIs", async function () {
+    it("answerMessageId is param[3] (non-indexed) in compiled ABI and both golden files", async function () {
       const { aiAgent } = await loadFixture(deployFixture);
 
-      const dappAbi = loadExternalAbi("sense-ai-dapp/src/lib/abi/EVMAIAgent.json");
-      const subgraphAbi = loadExternalAbi("sense-ai-subgraph/abis/EVMAIAgent.json");
+      const dappAbi = loadFixtureAbi("dapp-EVMAIAgent.json");
+      const subgraphAbi = loadFixtureAbi("subgraph-EVMAIAgent.json");
 
       for (const [label, abi] of [
         ["compiled", aiAgent.interface.fragments],
-        ["dApp", dappAbi],
-        ["subgraph", subgraphAbi],
+        ["dApp golden", dappAbi],
+        ["subgraph golden", subgraphAbi],
       ]) {
-        let fragment;
-        if (Array.isArray(abi)) {
-          // compiled interface fragments
-          fragment = abi.find((f) => f.name === "PromptSubmitted");
-        } else {
-          fragment = extractEventFragment(abi, "PromptSubmitted");
-        }
+        const fragment = Array.isArray(abi)
+          ? abi.find((f) => f.name === "PromptSubmitted")
+          : extractEventFragment(abi, "PromptSubmitted");
+
         expect(fragment, `${label}: PromptSubmitted not found`).to.not.be.undefined;
 
-        const inputs = Array.isArray(abi) ? fragment.inputs : fragment.inputs;
-        expect(inputs[3].name).to.equal(
+        expect(fragment.inputs[3].name).to.equal(
           "answerMessageId",
           `${label}: param[3] must be answerMessageId`,
         );
-        expect(inputs[3].indexed).to.equal(false, `${label}: answerMessageId must be non-indexed`);
+        expect(fragment.inputs[3].indexed).to.equal(
+          false,
+          `${label}: answerMessageId must be non-indexed`,
+        );
       }
     });
   });

--- a/test/PromptSubmitted.params.test.js
+++ b/test/PromptSubmitted.params.test.js
@@ -112,6 +112,16 @@ describe("Suite 1 — PromptSubmitted Event Parameter Order", function () {
   });
 
   describe("ABI sync: compiled artifact vs dApp ABI vs subgraph ABI", function () {
+    before(function () {
+      const sentinel = path.resolve(
+        __dirname,
+        "../../../../../sense-ai-dapp/src/lib/abi/EVMAIAgent.json",
+      );
+      if (!fs.existsSync(sentinel)) {
+        this.skip(); // sibling repos not checked out (CI single-repo environment)
+      }
+    });
+
     function loadExternalAbi(relPath) {
       const abs = path.resolve(__dirname, "../../../../../", relPath);
       const raw = JSON.parse(fs.readFileSync(abs, "utf8"));

--- a/test/PromptSubmitted.params.test.js
+++ b/test/PromptSubmitted.params.test.js
@@ -1,0 +1,188 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const path = require("path");
+const fs = require("fs");
+
+describe("Suite 1 — PromptSubmitted Event Parameter Order", function () {
+  const domain = "example.com";
+
+  async function deployFixture() {
+    const [deployer, user, oracle] = await ethers.getSigners();
+    const EVMAIAgent = await ethers.getContractFactory("EVMAIAgent");
+    const MockEscrowFactory = await ethers.getContractFactory("MockEVMAIAgentEscrow");
+
+    const aiAgent = await upgrades.deployProxy(
+      EVMAIAgent,
+      [domain, oracle.address, deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await aiAgent.waitForDeployment();
+
+    const mockEscrow = await MockEscrowFactory.deploy(await aiAgent.getAddress());
+    await mockEscrow.waitForDeployment();
+    await aiAgent.connect(deployer).setAgentEscrow(await mockEscrow.getAddress());
+
+    return { aiAgent, mockEscrow, user, oracle, deployer };
+  }
+
+  describe("Event signature and ABI encoding", function () {
+    it("should emit PromptSubmitted with correct parameter order: (user, conversationId, promptMessageId, answerMessageId, encryptedPayload, roflEncryptedKey)", async function () {
+      const { aiAgent, mockEscrow, user } = await loadFixture(deployFixture);
+
+      const conversationId = 1;
+      const promptMessageId = 0;
+      const answerMessageId = 1;
+      const encryptedPayload = "0xdeadbeef";
+      const roflEncryptedKey = "0xcafebabe";
+
+      const tx = await mockEscrow
+        .connect(user)
+        .callSubmitPrompt(
+          user.address,
+          conversationId,
+          promptMessageId,
+          answerMessageId,
+          encryptedPayload,
+          roflEncryptedKey,
+        );
+
+      const receipt = await tx.wait();
+
+      // Locate the PromptSubmitted log
+      const agentIface = aiAgent.interface;
+      const promptSubmittedTopic = agentIface.getEvent("PromptSubmitted").topicHash;
+      const log = receipt.logs.find((l) => l.topics[0] === promptSubmittedTopic);
+      expect(log, "PromptSubmitted log not found in receipt").to.not.be.undefined;
+
+      const parsed = agentIface.parseLog(log);
+
+      // Param index 0 (indexed): user address
+      expect(parsed.args[0]).to.equal(user.address, "param[0] must be user address");
+
+      // Param index 1 (indexed): conversationId
+      expect(parsed.args[1]).to.equal(BigInt(conversationId), "param[1] must be conversationId");
+
+      // Param index 2 (indexed): promptMessageId
+      expect(parsed.args[2]).to.equal(BigInt(promptMessageId), "param[2] must be promptMessageId");
+
+      // Param index 3 (non-indexed): answerMessageId — the universal linking key
+      expect(parsed.args[3]).to.equal(BigInt(answerMessageId), "param[3] must be answerMessageId");
+
+      // Param index 4 (non-indexed): encryptedPayload
+      expect(parsed.args[4]).to.equal(encryptedPayload, "param[4] must be encryptedPayload");
+
+      // Param index 5 (non-indexed): roflEncryptedKey
+      expect(parsed.args[5]).to.equal(roflEncryptedKey, "param[5] must be roflEncryptedKey");
+    });
+
+    it("should match the canonical ABI event definition exactly", async function () {
+      const { aiAgent } = await loadFixture(deployFixture);
+      const eventFragment = aiAgent.interface.getEvent("PromptSubmitted");
+
+      expect(eventFragment.name).to.equal("PromptSubmitted");
+
+      const inputs = eventFragment.inputs;
+      expect(inputs).to.have.length(6);
+
+      expect(inputs[0].name).to.equal("user");
+      expect(inputs[0].type).to.equal("address");
+      expect(inputs[0].indexed).to.be.true;
+
+      expect(inputs[1].name).to.equal("conversationId");
+      expect(inputs[1].type).to.equal("uint256");
+      expect(inputs[1].indexed).to.be.true;
+
+      expect(inputs[2].name).to.equal("promptMessageId");
+      expect(inputs[2].type).to.equal("uint256");
+      expect(inputs[2].indexed).to.be.true;
+
+      expect(inputs[3].name).to.equal("answerMessageId");
+      expect(inputs[3].type).to.equal("uint256");
+      expect(inputs[3].indexed).to.be.false;
+
+      expect(inputs[4].name).to.equal("encryptedPayload");
+      expect(inputs[4].type).to.equal("bytes");
+      expect(inputs[4].indexed).to.be.false;
+
+      expect(inputs[5].name).to.equal("roflEncryptedKey");
+      expect(inputs[5].type).to.equal("bytes");
+      expect(inputs[5].indexed).to.be.false;
+    });
+  });
+
+  describe("ABI sync: compiled artifact vs dApp ABI vs subgraph ABI", function () {
+    function loadExternalAbi(relPath) {
+      const abs = path.resolve(__dirname, "../../../../../", relPath);
+      const raw = JSON.parse(fs.readFileSync(abs, "utf8"));
+      return Array.isArray(raw) ? raw : raw.abi;
+    }
+
+    function extractEventFragment(abi, eventName) {
+      return abi.find((f) => f.type === "event" && f.name === eventName);
+    }
+
+    function normalisedInputs(fragment) {
+      return fragment.inputs.map((i) => ({
+        name: i.name,
+        type: i.type,
+        indexed: i.indexed,
+      }));
+    }
+
+    it("dApp ABI PromptSubmitted matches compiled ABI", async function () {
+      const { aiAgent } = await loadFixture(deployFixture);
+      const compiledFragment = aiAgent.interface.getEvent("PromptSubmitted");
+      const compiledInputs = normalisedInputs(compiledFragment);
+
+      const dappAbi = loadExternalAbi("sense-ai-dapp/src/lib/abi/EVMAIAgent.json");
+      const dappFragment = extractEventFragment(dappAbi, "PromptSubmitted");
+      expect(dappFragment, "dApp ABI missing PromptSubmitted event").to.not.be.undefined;
+
+      const dappInputs = normalisedInputs(dappFragment);
+      expect(dappInputs).to.deep.equal(compiledInputs);
+    });
+
+    it("subgraph ABI PromptSubmitted matches compiled ABI", async function () {
+      const { aiAgent } = await loadFixture(deployFixture);
+      const compiledFragment = aiAgent.interface.getEvent("PromptSubmitted");
+      const compiledInputs = normalisedInputs(compiledFragment);
+
+      const subgraphAbi = loadExternalAbi("sense-ai-subgraph/abis/EVMAIAgent.json");
+      const subgraphFragment = extractEventFragment(subgraphAbi, "PromptSubmitted");
+      expect(subgraphFragment, "Subgraph ABI missing PromptSubmitted event").to.not.be.undefined;
+
+      const subgraphInputs = normalisedInputs(subgraphFragment);
+      expect(subgraphInputs).to.deep.equal(compiledInputs);
+    });
+
+    it("answerMessageId is param[3] (non-indexed) in all three ABIs", async function () {
+      const { aiAgent } = await loadFixture(deployFixture);
+
+      const dappAbi = loadExternalAbi("sense-ai-dapp/src/lib/abi/EVMAIAgent.json");
+      const subgraphAbi = loadExternalAbi("sense-ai-subgraph/abis/EVMAIAgent.json");
+
+      for (const [label, abi] of [
+        ["compiled", aiAgent.interface.fragments],
+        ["dApp", dappAbi],
+        ["subgraph", subgraphAbi],
+      ]) {
+        let fragment;
+        if (Array.isArray(abi)) {
+          // compiled interface fragments
+          fragment = abi.find((f) => f.name === "PromptSubmitted");
+        } else {
+          fragment = extractEventFragment(abi, "PromptSubmitted");
+        }
+        expect(fragment, `${label}: PromptSubmitted not found`).to.not.be.undefined;
+
+        const inputs = Array.isArray(abi) ? fragment.inputs : fragment.inputs;
+        expect(inputs[3].name).to.equal(
+          "answerMessageId",
+          `${label}: param[3] must be answerMessageId`,
+        );
+        expect(inputs[3].indexed).to.equal(false, `${label}: answerMessageId must be non-indexed`);
+      }
+    });
+  });
+});

--- a/test/SpendingLimit.lifecycle.test.js
+++ b/test/SpendingLimit.lifecycle.test.js
@@ -225,7 +225,6 @@ describe("Suite 3 — SpendingLimit Lifecycle", function () {
       const { escrow, user } = await loadFixture(deployFixture);
       const expiresAt = (await time.latest()) + 7200;
       await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
-      await escrow.connect(user).initiatePrompt(0, "0x", "0x");
 
       const escrowIface = escrow.interface;
       const receipt = await (await escrow.connect(user).initiatePrompt(0, "0x", "0x")).wait();
@@ -238,8 +237,7 @@ describe("Suite 3 — SpendingLimit Lifecycle", function () {
       await escrow.connect(user).cancelPrompt(answerMessageId);
 
       const limit = await escrow.spendingLimits(user.address);
-      // First prompt's PROMPT_FEE remains + CANCELLATION_FEE for the cancelled prompt
-      expect(limit.spentAmount).to.equal(PROMPT_FEE + CANCELLATION_FEE);
+      expect(limit.spentAmount).to.equal(CANCELLATION_FEE);
     });
 
     it("after processRefund: spentAmount returns to 0 for that job's deduction", async function () {

--- a/test/SpendingLimit.lifecycle.test.js
+++ b/test/SpendingLimit.lifecycle.test.js
@@ -1,0 +1,265 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("Suite 3 — SpendingLimit Lifecycle", function () {
+  const domain = "example.com";
+  const INITIAL_ALLOWANCE = ethers.parseEther("100");
+  const PROMPT_FEE = ethers.parseEther("10");
+  const CANCELLATION_FEE = ethers.parseEther("1");
+  const METADATA_FEE = ethers.parseEther("0.5");
+  const BRANCH_FEE = ethers.parseEther("2");
+
+  async function deployFixture() {
+    const [deployer, user, oracle, treasury] = await ethers.getSigners();
+
+    const MockTokenFactory = await ethers.getContractFactory("MockAbleToken");
+    const token = await MockTokenFactory.deploy();
+    await token.waitForDeployment();
+    await token.mint(user.address, INITIAL_ALLOWANCE);
+
+    const EVMAIAgent = await ethers.getContractFactory("EVMAIAgent");
+    const aiAgent = await upgrades.deployProxy(
+      EVMAIAgent,
+      [domain, oracle.address, deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await aiAgent.waitForDeployment();
+
+    const EVMAIAgentEscrow = await ethers.getContractFactory("EVMAIAgentEscrow");
+    const escrow = await upgrades.deployProxy(
+      EVMAIAgentEscrow,
+      [
+        await token.getAddress(),
+        await aiAgent.getAddress(),
+        treasury.address,
+        deployer.address,
+        PROMPT_FEE,
+        CANCELLATION_FEE,
+        METADATA_FEE,
+        BRANCH_FEE,
+      ],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await escrow.waitForDeployment();
+
+    await aiAgent.connect(deployer).setAgentEscrow(await escrow.getAddress());
+    await token.connect(user).approve(await escrow.getAddress(), INITIAL_ALLOWANCE);
+
+    return { aiAgent, escrow, token, deployer, user, oracle, treasury };
+  }
+
+  describe("SpendingLimit struct field order", function () {
+    it("spendingLimits(user) returns fields in order: allowance, spentAmount, expiresAt", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      const limit = await escrow.spendingLimits(user.address);
+
+      expect(limit.allowance).to.equal(INITIAL_ALLOWANCE, "field[0] allowance mismatch");
+      expect(limit.spentAmount).to.equal(0n, "field[1] spentAmount should start at 0");
+      expect(limit.expiresAt).to.equal(BigInt(expiresAt), "field[2] expiresAt mismatch");
+    });
+  });
+
+  describe("setSpendingLimit events", function () {
+    it("emits SpendingLimitSet(user, allowance, expiresAt) — all three indexed", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 3600;
+
+      await expect(escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt))
+        .to.emit(escrow, "SpendingLimitSet")
+        .withArgs(user.address, INITIAL_ALLOWANCE, expiresAt);
+    });
+
+    it("SpendingLimitSet event inputs are all indexed", async function () {
+      const { escrow } = await loadFixture(deployFixture);
+      const fragment = escrow.interface.getEvent("SpendingLimitSet");
+
+      expect(fragment.inputs).to.have.length(3);
+      expect(fragment.inputs[0].name).to.equal("user");
+      expect(fragment.inputs[0].indexed).to.be.true;
+      expect(fragment.inputs[1].name).to.equal("allowance");
+      expect(fragment.inputs[1].indexed).to.be.true;
+      expect(fragment.inputs[2].name).to.equal("expiresAt");
+      expect(fragment.inputs[2].indexed).to.be.true;
+    });
+
+    it("reverts with ZeroSpendingLimit when allowance is 0", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 3600;
+
+      await expect(
+        escrow.connect(user).setSpendingLimit(0, expiresAt),
+      ).to.be.revertedWithCustomError(escrow, "ZeroSpendingLimit");
+    });
+
+    it("reverts with ExpirationInThePast when expiresAt is 0", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+
+      await expect(
+        escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, 0),
+      ).to.be.revertedWithCustomError(escrow, "ExpirationInThePast");
+    });
+
+    it("reverts with ExpirationInThePast when expiresAt <= block.timestamp", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const now = await time.latest();
+
+      await expect(
+        escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, now),
+      ).to.be.revertedWithCustomError(escrow, "ExpirationInThePast");
+    });
+  });
+
+  describe("cancelSpendingLimit events and state", function () {
+    it("emits SpendingLimitCancelled(user) and zeroes the struct", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      await expect(escrow.connect(user).cancelSpendingLimit())
+        .to.emit(escrow, "SpendingLimitCancelled")
+        .withArgs(user.address);
+
+      const limit = await escrow.spendingLimits(user.address);
+      expect(limit.allowance).to.equal(0n);
+      expect(limit.spentAmount).to.equal(0n);
+      expect(limit.expiresAt).to.equal(0n);
+    });
+
+    it("SpendingLimitCancelled input is indexed", async function () {
+      const { escrow } = await loadFixture(deployFixture);
+      const fragment = escrow.interface.getEvent("SpendingLimitCancelled");
+
+      expect(fragment.inputs).to.have.length(1);
+      expect(fragment.inputs[0].name).to.equal("user");
+      expect(fragment.inputs[0].indexed).to.be.true;
+    });
+  });
+
+  describe("spentAmount deduction tracking", function () {
+    it("each initiatePrompt increments spentAmount by PROMPT_FEE; allowance stays static", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 7200;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+
+      let limit = await escrow.spendingLimits(user.address);
+      expect(limit.spentAmount).to.equal(
+        PROMPT_FEE,
+        "spentAmount should be PROMPT_FEE after first prompt",
+      );
+      expect(limit.allowance).to.equal(INITIAL_ALLOWANCE, "allowance must not change");
+
+      // Finalize so the second prompt can proceed
+      const agentIface = aiAgent.interface;
+      const escrowIface = escrow.interface;
+
+      const receipt1 = await (await escrow.connect(user).initiatePrompt(0, "0x", "0x")).wait();
+      const escrowLog1 = receipt1.logs.find(
+        (l) => l.topics[0] === escrowIface.getEvent("PaymentEscrowed").topicHash,
+      );
+      const answerMessageId1 = escrowIface.parseLog(escrowLog1).args[0];
+      const agentLog1 = receipt1.logs.find(
+        (l) => l.topics[0] === agentIface.getEvent("PromptSubmitted").topicHash,
+      );
+      const promptMessageId1 = agentIface.parseLog(agentLog1).args[2];
+
+      limit = await escrow.spendingLimits(user.address);
+      expect(limit.spentAmount).to.equal(
+        PROMPT_FEE * 2n,
+        "spentAmount should be 2x PROMPT_FEE after second prompt",
+      );
+
+      const cidBundle = {
+        conversationCID: "QmXg9j4f8zYf8t7",
+        metadataCID: "QmXg9j4f8zYf8t7",
+        promptMessageCID: "QmXg9j4f8zYf8t7",
+        answerMessageCID: "QmXg9j4f8zYf8t7",
+        searchDeltaCID: "QmXg9j4f8zYf8t7",
+      };
+      await aiAgent.connect(oracle).submitAnswer(promptMessageId1, answerMessageId1, cidBundle);
+    });
+  });
+
+  describe("NoActiveSpendingLimit sentinel", function () {
+    it("initiatePrompt reverts with NoActiveSpendingLimit when no limit is set", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+
+      await expect(
+        escrow.connect(user).initiatePrompt(0, "0x", "0x"),
+      ).to.be.revertedWithCustomError(escrow, "NoActiveSpendingLimit");
+    });
+
+    it("initiatePrompt reverts with NoActiveSpendingLimit after cancelSpendingLimit", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+      await escrow.connect(user).cancelSpendingLimit();
+
+      await expect(
+        escrow.connect(user).initiatePrompt(0, "0x", "0x"),
+      ).to.be.revertedWithCustomError(escrow, "NoActiveSpendingLimit");
+    });
+  });
+
+  describe("SpendingLimitExpired sentinel", function () {
+    it("initiatePrompt reverts with SpendingLimitExpired once expiresAt has passed", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 5;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      await time.increase(10);
+
+      await expect(
+        escrow.connect(user).initiatePrompt(0, "0x", "0x"),
+      ).to.be.revertedWithCustomError(escrow, "SpendingLimitExpired");
+    });
+  });
+
+  describe("spentAmount after cancel and refund", function () {
+    it("after cancelPrompt: spentAmount equals CANCELLATION_FEE (prompt fee refunded, cancel fee charged)", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 7200;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+      await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+
+      const escrowIface = escrow.interface;
+      const receipt = await (await escrow.connect(user).initiatePrompt(0, "0x", "0x")).wait();
+      const escrowLog = receipt.logs.find(
+        (l) => l.topics[0] === escrowIface.getEvent("PaymentEscrowed").topicHash,
+      );
+      const answerMessageId = escrowIface.parseLog(escrowLog).args[0];
+
+      await time.increase(5);
+      await escrow.connect(user).cancelPrompt(answerMessageId);
+
+      const limit = await escrow.spendingLimits(user.address);
+      // First prompt's PROMPT_FEE remains + CANCELLATION_FEE for the cancelled prompt
+      expect(limit.spentAmount).to.equal(PROMPT_FEE + CANCELLATION_FEE);
+    });
+
+    it("after processRefund: spentAmount returns to 0 for that job's deduction", async function () {
+      const { escrow, user } = await loadFixture(deployFixture);
+      const expiresAt = (await time.latest()) + 7200;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      const escrowIface = escrow.interface;
+      const receipt = await (await escrow.connect(user).initiatePrompt(0, "0x", "0x")).wait();
+      const escrowLog = receipt.logs.find(
+        (l) => l.topics[0] === escrowIface.getEvent("PaymentEscrowed").topicHash,
+      );
+      const answerMessageId = escrowIface.parseLog(escrowLog).args[0];
+
+      // Wait past REFUND_TIMEOUT (1 hour)
+      await time.increase(3601);
+      await escrow.connect(user).processRefund(answerMessageId);
+
+      const limit = await escrow.spendingLimits(user.address);
+      expect(limit.spentAmount).to.equal(0n, "spentAmount should be 0 after full refund");
+    });
+  });
+});

--- a/test/answerMessageId.lifecycle.test.js
+++ b/test/answerMessageId.lifecycle.test.js
@@ -1,0 +1,263 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("Suite 2 — answerMessageId as Universal Linking Key", function () {
+  const domain = "example.com";
+  const INITIAL_ALLOWANCE = ethers.parseEther("100");
+  const PROMPT_FEE = ethers.parseEther("10");
+  const CANCELLATION_FEE = ethers.parseEther("1");
+  const METADATA_FEE = ethers.parseEther("0.5");
+  const BRANCH_FEE = ethers.parseEther("2");
+  const MOCK_CID = "QmXg9j4f8zYf8t7f8zYf8t7f8zYf8t7f8zYf8t7f8zYf8t7";
+
+  // Deploy both real contracts wired together (no mocks).
+  async function deployFullFixture() {
+    const [deployer, user, oracle, treasury] = await ethers.getSigners();
+
+    const MockTokenFactory = await ethers.getContractFactory("MockAbleToken");
+    const token = await MockTokenFactory.deploy();
+    await token.waitForDeployment();
+    await token.mint(user.address, INITIAL_ALLOWANCE);
+
+    const EVMAIAgent = await ethers.getContractFactory("EVMAIAgent");
+    const aiAgent = await upgrades.deployProxy(
+      EVMAIAgent,
+      [domain, oracle.address, deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await aiAgent.waitForDeployment();
+
+    const EVMAIAgentEscrow = await ethers.getContractFactory("EVMAIAgentEscrow");
+    const escrow = await upgrades.deployProxy(
+      EVMAIAgentEscrow,
+      [
+        await token.getAddress(),
+        await aiAgent.getAddress(),
+        treasury.address,
+        deployer.address,
+        PROMPT_FEE,
+        CANCELLATION_FEE,
+        METADATA_FEE,
+        BRANCH_FEE,
+      ],
+      { initializer: "initialize", kind: "uups" },
+    );
+    await escrow.waitForDeployment();
+
+    await aiAgent.connect(deployer).setAgentEscrow(await escrow.getAddress());
+    await token.connect(user).approve(await escrow.getAddress(), INITIAL_ALLOWANCE);
+
+    return { aiAgent, escrow, token, deployer, user, oracle, treasury };
+  }
+
+  describe("answerMessageId links PaymentEscrowed → PromptSubmitted", function () {
+    it("answerMessageId from PaymentEscrowed equals param[3] of PromptSubmitted", async function () {
+      const { aiAgent, escrow, user } = await loadFixture(deployFullFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      const tx = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+      const receipt = await tx.wait();
+
+      // Extract answerMessageId from PaymentEscrowed (escrow contract)
+      const escrowIface = escrow.interface;
+      const paymentEscrowedTopic = escrowIface.getEvent("PaymentEscrowed").topicHash;
+      const escrowLog = receipt.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+      expect(escrowLog, "PaymentEscrowed not found").to.not.be.undefined;
+      const escrowParsed = escrowIface.parseLog(escrowLog);
+      const escrowedAnswerMessageId = escrowParsed.args[0]; // escrowId == answerMessageId
+
+      // Extract answerMessageId from PromptSubmitted (agent contract)
+      const agentIface = aiAgent.interface;
+      const promptSubmittedTopic = agentIface.getEvent("PromptSubmitted").topicHash;
+      const agentLog = receipt.logs.find((l) => l.topics[0] === promptSubmittedTopic);
+      expect(agentLog, "PromptSubmitted not found").to.not.be.undefined;
+      const agentParsed = agentIface.parseLog(agentLog);
+      const submittedAnswerMessageId = agentParsed.args[3]; // non-indexed param[3]
+
+      expect(escrowedAnswerMessageId).to.equal(
+        submittedAnswerMessageId,
+        "answerMessageId must be the same in PaymentEscrowed (escrowId) and PromptSubmitted (param[3])",
+      );
+    });
+  });
+
+  describe("Full prompt lifecycle using answerMessageId as the key", function () {
+    it("answerMessageId flows through initiatePrompt → submitAnswer → PaymentFinalized", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFullFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      // Step 1: initiate prompt — captures answerMessageId
+      const initTx = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+      const initReceipt = await initTx.wait();
+
+      const escrowIface = escrow.interface;
+      const paymentEscrowedTopic = escrowIface.getEvent("PaymentEscrowed").topicHash;
+      const escrowLog = initReceipt.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+      const escrowParsed = escrowIface.parseLog(escrowLog);
+      const answerMessageId = escrowParsed.args[0];
+
+      // Retrieve promptMessageId from PromptSubmitted
+      const agentIface = aiAgent.interface;
+      const promptSubmittedTopic = agentIface.getEvent("PromptSubmitted").topicHash;
+      const agentLog = initReceipt.logs.find((l) => l.topics[0] === promptSubmittedTopic);
+      const agentParsed = agentIface.parseLog(agentLog);
+      const promptMessageId = agentParsed.args[2]; // indexed param[2]
+
+      // Step 2: oracle submits answer using the same answerMessageId
+      const cidBundle = {
+        conversationCID: MOCK_CID,
+        metadataCID: MOCK_CID,
+        promptMessageCID: MOCK_CID,
+        answerMessageCID: MOCK_CID,
+        searchDeltaCID: MOCK_CID,
+      };
+
+      await expect(
+        aiAgent.connect(oracle).submitAnswer(promptMessageId, answerMessageId, cidBundle),
+      )
+        .to.emit(escrow, "PaymentFinalized")
+        .withArgs(answerMessageId)
+        .and.to.emit(aiAgent, "AnswerMessageAdded");
+
+      // Step 3: verify escrow job is finalized using that answerMessageId
+      expect(await aiAgent.isJobFinalized(answerMessageId)).to.be.true;
+    });
+
+    it("answerMessageId flows through initiatePrompt → cancelPrompt → PromptCancelled on both contracts", async function () {
+      const { aiAgent, escrow, user } = await loadFixture(deployFullFixture);
+      const expiresAt = (await time.latest()) + 7200;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      const initTx = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+      const initReceipt = await initTx.wait();
+
+      const escrowIface = escrow.interface;
+      const paymentEscrowedTopic = escrowIface.getEvent("PaymentEscrowed").topicHash;
+      const escrowLog = initReceipt.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+      const escrowParsed = escrowIface.parseLog(escrowLog);
+      const answerMessageId = escrowParsed.args[0];
+
+      // Wait past cancellation timeout
+      await time.increase(5);
+
+      const agentIface = aiAgent.interface;
+
+      await expect(escrow.connect(user).cancelPrompt(answerMessageId))
+        .to.emit(escrow, "PromptCancelled")
+        .withArgs(user.address, answerMessageId)
+        .and.to.emit(aiAgent, "PromptCancelled")
+        .withArgs(user.address, answerMessageId);
+
+      // answerMessageId is now finalized in the agent (cancelled = finalized)
+      expect(await aiAgent.isJobFinalized(answerMessageId)).to.be.true;
+    });
+  });
+
+  describe("Multiple prompts — answerMessageId uniqueness", function () {
+    it("each prompt gets a distinct answerMessageId that tracks independently", async function () {
+      const { aiAgent, escrow, user, oracle } = await loadFixture(deployFullFixture);
+      const expiresAt = (await time.latest()) + 7200;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      // First prompt
+      const tx1 = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+      const receipt1 = await tx1.wait();
+      const escrowIface = escrow.interface;
+      const agentIface = aiAgent.interface;
+      const paymentEscrowedTopic = escrowIface.getEvent("PaymentEscrowed").topicHash;
+      const promptSubmittedTopic = agentIface.getEvent("PromptSubmitted").topicHash;
+
+      const escrowLog1 = receipt1.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+      const answerMessageId1 = escrowIface.parseLog(escrowLog1).args[0];
+      const agentLog1 = receipt1.logs.find((l) => l.topics[0] === promptSubmittedTopic);
+      const promptMessageId1 = agentIface.parseLog(agentLog1).args[2];
+
+      // Submit first answer to free up the spending limit for a second prompt
+      const cidBundle = {
+        conversationCID: MOCK_CID,
+        metadataCID: MOCK_CID,
+        promptMessageCID: MOCK_CID,
+        answerMessageCID: MOCK_CID,
+        searchDeltaCID: MOCK_CID,
+      };
+      await aiAgent.connect(oracle).submitAnswer(promptMessageId1, answerMessageId1, cidBundle);
+
+      // Second prompt — use existing conversationId (already owned by user)
+      const conversationId1 = agentIface.parseLog(agentLog1).args[1];
+      const tx2 = await escrow.connect(user).initiatePrompt(conversationId1, "0x", "0x");
+      const receipt2 = await tx2.wait();
+
+      const escrowLog2 = receipt2.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+      const answerMessageId2 = escrowIface.parseLog(escrowLog2).args[0];
+      const agentLog2 = receipt2.logs.find((l) => l.topics[0] === promptSubmittedTopic);
+      const promptMessageId2 = agentIface.parseLog(agentLog2).args[2];
+
+      expect(answerMessageId1).to.not.equal(answerMessageId2, "answerMessageIds must be unique");
+      expect(promptMessageId1).to.not.equal(promptMessageId2, "promptMessageIds must be unique");
+
+      // First is finalized; second is not
+      expect(await aiAgent.isJobFinalized(answerMessageId1)).to.be.true;
+      expect(await aiAgent.isJobFinalized(answerMessageId2)).to.be.false;
+
+      // Finalize second
+      const subsequentBundle = {
+        conversationCID: "",
+        metadataCID: "",
+        promptMessageCID: MOCK_CID,
+        answerMessageCID: MOCK_CID,
+        searchDeltaCID: MOCK_CID,
+      };
+      await aiAgent
+        .connect(oracle)
+        .submitAnswer(promptMessageId2, answerMessageId2, subsequentBundle);
+      expect(await aiAgent.isJobFinalized(answerMessageId2)).to.be.true;
+    });
+  });
+
+  describe("UUPS upgradeability preserved in full deployment", function () {
+    it("agent retains state after upgrade with no answerMessageId corruption", async function () {
+      const { aiAgent, escrow, user, oracle, deployer } = await loadFixture(deployFullFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+
+      const initTx = await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+      const initReceipt = await initTx.wait();
+
+      const escrowIface = escrow.interface;
+      const paymentEscrowedTopic = escrowIface.getEvent("PaymentEscrowed").topicHash;
+      const escrowLog = initReceipt.logs.find((l) => l.topics[0] === paymentEscrowedTopic);
+      const answerMessageId = escrowIface.parseLog(escrowLog).args[0];
+
+      // Upgrade agent
+      const V2Factory = await ethers.getContractFactory("EVMAIAgentV2");
+      const upgradedAgent = await upgrades.upgradeProxy(await aiAgent.getAddress(), V2Factory, {
+        signer: deployer,
+      });
+      expect(await upgradedAgent.version()).to.equal("2.0");
+
+      // answerMessageId is still not finalized after upgrade
+      expect(await upgradedAgent.isJobFinalized(answerMessageId)).to.be.false;
+    });
+
+    it("escrow retains state after upgrade with no escrowId corruption", async function () {
+      const { escrow, user, deployer } = await loadFixture(deployFullFixture);
+      const expiresAt = (await time.latest()) + 3600;
+      await escrow.connect(user).setSpendingLimit(INITIAL_ALLOWANCE, expiresAt);
+      await escrow.connect(user).initiatePrompt(0, "0x", "0x");
+
+      const V2Factory = await ethers.getContractFactory("EVMAIAgentEscrowV2");
+      const upgradedEscrow = await upgrades.upgradeProxy(await escrow.getAddress(), V2Factory, {
+        signer: deployer,
+      });
+      expect(await upgradedEscrow.version()).to.equal("2.0");
+
+      // Spending limit state survives upgrade
+      const limit = await upgradedEscrow.spendingLimits(user.address);
+      expect(limit.allowance).to.equal(INITIAL_ALLOWANCE);
+      expect(limit.spentAmount).to.equal(PROMPT_FEE);
+    });
+  });
+});

--- a/test/fixtures/dapp-EVMAIAgent.json
+++ b/test/fixtures/dapp-EVMAIAgent.json
@@ -1,0 +1,1269 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AgentEscrowAlreadySet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AnswerCIDRequired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "ERC1967InvalidImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1967NonPayable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPromptMessageId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "JobAlreadyFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotAIAgentEscrow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RegenerationAlreadyPending",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UUPSUnauthorizedCallContext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UUPSUnsupportedProxiableUUID",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnauthorizedOracle",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAIAgentEscrow",
+        "type": "address"
+      }
+    ],
+    "name": "AgentEscrowUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "jobId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "triggerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "AgentJobSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "messageCID",
+        "type": "string"
+      }
+    ],
+    "name": "AnswerMessageAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "BranchRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "conversationCID",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "ConversationAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "conversationCID",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "ConversationBranched",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newConversationMetadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "ConversationMetadataUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "MetadataUpdateRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOracle",
+        "type": "address"
+      }
+    ],
+    "name": "OracleUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "answerMessageId",
+        "type": "uint256"
+      }
+    ],
+    "name": "PromptCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "messageCID",
+        "type": "string"
+      }
+    ],
+    "name": "PromptMessageAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "PromptSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "originalAnswerMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "RegenerationRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "searchDeltaCID",
+        "type": "string"
+      }
+    ],
+    "name": "SearchIndexDeltaAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "aiAgentEscrow",
+    "outputs": [
+      {
+        "internalType": "contract IEVMAIAgentEscrow",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "conversationIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "conversationToOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "domain",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_domain",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_oracle",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_initialOwner",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "isJobFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "isRegenerationPending",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "jobIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "jobToOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "messageIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "messageToConversation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      }
+    ],
+    "name": "recordCancellation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveConversationId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveJobId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveMessageId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveTriggerId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newAIAgentEscrow",
+        "type": "address"
+      }
+    ],
+    "name": "setAgentEscrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newOracle",
+        "type": "address"
+      }
+    ],
+    "name": "setOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_jobId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_triggerId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitAgentJob",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "conversationCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "promptMessageCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "answerMessageCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "searchDeltaCID",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct Structs.CidBundle",
+        "name": "_cids",
+        "type": "tuple"
+      }
+    ],
+    "name": "submitAnswer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_conversationCID",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_metadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "submitBranch",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitBranchRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_newConversationMetadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "submitConversationMetadata",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitMetadataUpdate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitPrompt",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originalAnswerMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitRegenerationRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "triggerIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "triggerToJob",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/test/fixtures/subgraph-EVMAIAgent.json
+++ b/test/fixtures/subgraph-EVMAIAgent.json
@@ -1,0 +1,1269 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AgentEscrowAlreadySet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AnswerCIDRequired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "ERC1967InvalidImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1967NonPayable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPromptMessageId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "JobAlreadyFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotAIAgentEscrow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RegenerationAlreadyPending",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UUPSUnauthorizedCallContext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UUPSUnsupportedProxiableUUID",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnauthorizedOracle",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAIAgentEscrow",
+        "type": "address"
+      }
+    ],
+    "name": "AgentEscrowUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "jobId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "triggerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "AgentJobSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "messageCID",
+        "type": "string"
+      }
+    ],
+    "name": "AnswerMessageAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "BranchRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "conversationCID",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "ConversationAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "conversationCID",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "ConversationBranched",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newConversationMetadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "ConversationMetadataUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "MetadataUpdateRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOracle",
+        "type": "address"
+      }
+    ],
+    "name": "OracleUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "answerMessageId",
+        "type": "uint256"
+      }
+    ],
+    "name": "PromptCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "messageCID",
+        "type": "string"
+      }
+    ],
+    "name": "PromptMessageAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "PromptSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "conversationId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "originalAnswerMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "RegenerationRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "searchDeltaCID",
+        "type": "string"
+      }
+    ],
+    "name": "SearchIndexDeltaAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "aiAgentEscrow",
+    "outputs": [
+      {
+        "internalType": "contract IEVMAIAgentEscrow",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "conversationIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "conversationToOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "domain",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_domain",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_oracle",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_initialOwner",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "isJobFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "isRegenerationPending",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "jobIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "jobToOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "messageIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "messageToConversation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      }
+    ],
+    "name": "recordCancellation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveConversationId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveJobId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveMessageId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveTriggerId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newAIAgentEscrow",
+        "type": "address"
+      }
+    ],
+    "name": "setAgentEscrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newOracle",
+        "type": "address"
+      }
+    ],
+    "name": "setOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_jobId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_triggerId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitAgentJob",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "conversationCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "promptMessageCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "answerMessageCID",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "searchDeltaCID",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct Structs.CidBundle",
+        "name": "_cids",
+        "type": "tuple"
+      }
+    ],
+    "name": "submitAnswer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_conversationCID",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_metadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "submitBranch",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originalConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_branchPointMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newConversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitBranchRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_newConversationMetadataCID",
+        "type": "string"
+      }
+    ],
+    "name": "submitConversationMetadata",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitMetadataUpdate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitPrompt",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conversationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_promptMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originalAnswerMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_answerMessageId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_encryptedPayload",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_roflEncryptedKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "submitRegenerationRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "triggerIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "triggerToJob",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
## Summary

- Adds 4 test suites encoding the critical cross-repo continuity contracts that link `tokenized-ai-agent`, `sense-ai-subgraph`, and `sense-ai-dapp`
- These tests will catch silent regressions from contract changes before they reach production

## Tests added

| File | What it guards |
|------|---------------|
| `PromptSubmitted.params.test.js` | Event param order is exactly `(user, conversationId, promptMessageId, answerMessageId, encryptedPayload, roflEncryptedKey)`; compiled ABI === dApp ABI === subgraph ABI |
| `answerMessageId.lifecycle.test.js` | `initiatePrompt()` → `PromptSubmitted[3]` → `finalizePayment(answerMessageId)` round-trip; the universal linking key flows correctly through all four layers |
| `CidBundle.fieldOrder.test.js` | `CidBundle` struct field order matches oracle assembly expectations |
| `SpendingLimit.lifecycle.test.js` | `setSpendingLimit()` → deducts on `initiatePrompt()` → `cancelSpendingLimit()` removes it |

## Why these tests matter

`answerMessageId` at param index 3 of `PromptSubmitted` is the single ID linking:
- Escrow payment → PromptRequest entity → Payment entity in the subgraph
- dApp receipt log parsing at hardcoded index 3

If this ever shifts, all three downstream consumers break silently. These tests are the safety net.

## Test plan

- [ ] `npm test` passes all tests including the 4 new files
- [ ] No regressions in existing `EVMAIAgent.test.js`, `EVMAIAgentEscrow.test.js` etc.
- [ ] Cross-ABI checks in `PromptSubmitted.params.test.js` require `sense-ai-dapp` and `sense-ai-subgraph` to be sibling directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)