### PR TITLE
docs(readme): add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Tokenized AI Agent
 
+[![CI](https://img.shields.io/github/actions/workflow/status/TradableApp/tokenized-ai-agent/ci.yml?branch=main&label=CI)](https://github.com/TradableApp/tokenized-ai-agent/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/TradableApp/tokenized-ai-agent.svg)](./LICENSE)
 [![Built with Oasis ROFL](https://img.shields.io/badge/built%20with-oasis%20rofl-7a00ff.svg)](https://docs.oasis.io/build/rofl/)
 


### PR DESCRIPTION
Adds a CI status badge to the README, matching the existing shields.io license badge style (build-status first). Docs-only; no code impact.