### PR TITLE
chore(ci): refactor dependabot — monthly + cooldown + groups, ignore semver-majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
-    cooldown:
-      semver-patch-days: 3
-      semver-minor-days: 7
-      semver-major-days: 30
     groups:
       github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -22,6 +19,8 @@ updates:
     directories:
       - /
       - /oracle
+      # Bundled ElizaOS plugin required at runtime by oracle/src/aiAgentOracle.js
+      # (own package.json + bun.lock; ships axios/zod/@elizaos deps).
       - /oracle/src/elizaos/plugins/plugin-senseai
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,39 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
+    groups:
+      github-actions:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: bun
     directories:
       - /
       - /oracle
-      # Bundled ElizaOS plugin required at runtime by oracle/src/aiAgentOracle.js
-      # (own package.json + bun.lock; ships axios/zod/@elizaos deps).
       - /oracle/src/elizaos/plugins/plugin-senseai
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
+    groups:
+      all-non-major:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Refactors `.github/dependabot.yml` to reduce PR volume and noise while preserving security update coverage.

**Before:** weekly schedule, no grouping, no cooldown, all majors offered.
**After:** monthly schedule, grouped minor+patch, cooldown (3d/7d/30d) where the ecosystem supports it, majors ignored.

## What changes

| Setting | Before | After |
|---|---|---|
| Schedule | weekly | **monthly** |
| Cooldown | none | **3d patch / 7d minor / 30d major** (bun only — github-actions uses tag/SHA refs, doesn't accept cooldown) |
| Grouping | none | **all minor+patch in one PR per ecosystem** |
| Majors | offered | **ignored** (handled manually as feature work) |
| Security alerts | bypassed cooldown | **still bypassed** (unchanged) |

The bun ecosystem preserves its existing multi-directory coverage (`/`, `/oracle`, `/oracle/src/elizaos/plugins/plugin-senseai`), with the explanatory comment about the nested ElizaOS plugin retained.

## Why

The previous config opened individual PRs per dependency on a weekly cadence. With multiple ecosystems and frequent upstream releases, this created PR thrash without proportional security value. The new policy keeps Dependabot's security signal intact — security-flagged bumps still bypass cooldown — while consolidating routine bumps into predictable monthly batches.

Both group rules use `patterns: ["*"]` plus `update-types: ["minor", "patch"]` as belt-and-braces (resilient against known Dependabot edge cases where `update-types:`-only groups can silently no-op).

`cooldown:` is omitted from the `github-actions` ecosystem because Dependabot only supports it on semver-versioned ecosystems (bun/npm/pip/cargo/etc.). GitHub Actions references are tag/SHA-based.

## Test plan

- [ ] CI passes
- [ ] `.github/dependabot.yml` validation passes
- [ ] Visual inspection of diff — bun `directories:` list unchanged
