### PR TITLE
chore(ci): tune Claude limits — 100 turns / 30min + budget-aware triage prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ jobs:
     # On-demand: only runs when the `claude-review` label is added to a PR
     if: github.event.label.name == 'claude-review'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30   # true backstop — bounds wall-clock/quota for large PRs
     permissions:
       contents: read
       pull-requests: write   # write required to post inline PR review comments
@@ -37,12 +37,21 @@ jobs:
             Author: ${{ github.event.pull_request.user.login }}
             Branch: ${{ github.event.pull_request.head.ref }} → ${{ github.event.pull_request.base.ref }}
 
-            STEPS:
-            1. Read CLAUDE.md (and .claude/CLAUDE.md if present) to understand project conventions, architecture, and non-obvious constraints.
-            2. Run: git diff origin/${{ github.event.pull_request.base.ref }}...HEAD --stat
-            3. Run: git diff origin/${{ github.event.pull_request.base.ref }}...HEAD
-            4. For files where surrounding context matters, read the full file — do not review diffs in isolation.
-            5. Post your findings as INLINE review comments on the exact diff lines where each issue occurs (these become resolvable threads), then a short summary comment.
+            APPROACH (you have a finite tool budget — spend it on what matters):
+            1. Read CLAUDE.md (and .claude/CLAUDE.md if present) for conventions and constraints.
+            2. Run: git diff origin/${{ github.event.pull_request.base.ref }}...HEAD --stat — SIZE the PR before reading anything in full.
+            3. SCOPE the review:
+               - Prioritise hand-written source, security-sensitive code, DB migrations, auth, financial/money logic, and business rules.
+               - SKIP the noise and just note you skipped it: lockfiles, *.lock, generated OpenAPI/SDK/client output, snapshots, build artefacts, vendored code, large fixtures/data, and pure formatting churn.
+               - On LARGE PRs (>40 files or >2,000 changed lines): do NOT read every file. Triage to the highest-risk files and review those deeply.
+            4. For files where surrounding context matters, read the full file — don't review diffs in isolation.
+            5. Post findings as INLINE review comments on the exact diff lines (resolvable threads), then a short summary comment.
+
+            BUDGET DISCIPLINE (critical — a partial review that is POSTED beats an exhaustive one that never lands):
+            - Posting your review is MANDATORY. Never end the run without posting inline comments and/or a summary.
+            - Post inline comments AS YOU FIND issues — do not defer all posting to the very end.
+            - If you sense you are running low on budget, STOP investigating immediately and post the findings you have, plus one line on what you did not cover and why.
+            - On very large PRs, an explicit "I focused on X and Y; I did not deep-review the generated/Z files" summary is a good outcome.
 
             PRIORITY ORDER:
             🔴 Bugs — logic errors, wrong conditions, off-by-ones, race conditions, unhandled edge cases
@@ -59,8 +68,8 @@ jobs:
             - 3 real findings beat 10 nitpicks
             - Do not suggest reverting intentional decisions or patterns documented in CLAUDE.md
           claude_args: |
-            --max-turns 15
+            --max-turns 100
             --allowedTools Read,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(git blame*),Bash(grep*),Bash(find . *)
-            --system-prompt "You are an independent senior code reviewer. You did NOT write this code and have no prior context — your job is to catch real bugs, security issues, and quality problems that the author and their coding assistant may have missed. Post each finding as an inline review comment on the specific diff line. Be direct and specific. Do not over-comment."
+            --system-prompt "You are an independent senior code reviewer. You did NOT write this code and have no prior context — your job is to catch real bugs, security issues, and quality problems that the author and their coding assistant may have missed. Be efficient with your tool budget: size the PR first, triage to the highest-risk changes on large PRs, and skip generated/vendored noise. Posting your review is mandatory — always post inline comments and a summary before ending, even if your coverage is partial. Be direct and specific; do not over-comment."
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -31,4 +31,5 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --system-prompt "You are Claude responding to an @claude mention. Answer the request as asked. IF AND ONLY IF you are asked to review code or a pull request: post each finding as an INLINE comment on the specific diff line it refers to (these become resolvable review threads, like GitHub Copilot's review), then post one short summary comment with the overall assessment. Group findings by severity: 🔴 bug/security (should fix before merge), 🟡 suggestion (non-blocking), 🟣 pre-existing (not introduced by this PR). Explain WHY each is a problem and give a concrete fix. Do not over-comment — a few real findings beat many nitpicks. For any request that is NOT a code/PR review, respond normally in a single comment and do NOT post inline review comments."
+            --max-turns 100
+            --system-prompt "You are Claude responding to an @claude mention. Answer the request as asked, posting your response as a comment. IF you are asked to review code or a PR: do a budget-aware review — first size the PR with git diff --stat; prioritise hand-written source, security-sensitive code, DB migrations, auth, and financial/money logic; SKIP generated/lockfile/SDK-dump/vendored/snapshot noise; on large PRs (>40 files or >2,000 changed lines) triage to the highest-risk files and review those deeply. Post your findings as a structured comment grouped by severity (🔴 bug/security, 🟡 perf/completeness/convention, 🟣 pre-existing), each with WHY plus a concrete fix. Be efficient with your tool budget and ALWAYS post your review before ending, even if coverage is partial (note what you skipped and why). For any request that is NOT a code/PR review, just answer normally. Do not over-comment — 3 real findings beat 10 nitpicks. Note: you respond via comments only; you cannot post inline resolvable review threads (use the `claude-review` label workflow for that)."


### PR DESCRIPTION
## What
Tunes **both** Claude workflows for production so large PRs produce a focused review instead of erroring out.

Context: omni-fi-core PR #303 (650 files, +46,808 lines) hit the old 15-turn cap at turn 16 in ~4 min and posted **nothing**.

## Changes (applied to `claude-code-review.yml` and `claude.yml`)
- `--max-turns` → **100** (loop-guard headroom — ~120 turns fit in 30 min)
- `timeout-minutes` → **30** (the true wall-clock / quota backstop)
- Prompt → **size-first triage** (skip generated/lockfile/SDK noise; deep-review highest-risk files on big PRs) + **mandatory incremental posting** (always post a review, even if partial)

## Same tuning, two modes
- **`claude-code-review.yml`** — `claude-review` label → real **inline** resolvable review threads.
- **`claude.yml`** — `@claude` comment → **comment-only** review (tag mode cannot post inline threads).
