### PR TITLE
feat(oracle): local IPFS storage provider for localnet e2e [Phase 2A]

### DIFF
--- a/oracle/src/storage/ipfs.js
+++ b/oracle/src/storage/ipfs.js
@@ -1,0 +1,102 @@
+/**
+ * @file ipfs.js
+ * @notice Local IPFS (Kubo) storage provider — LOCALNET ONLY.
+ *
+ * Mirrors the autonomys/arweave provider interface (`uploadData`/`fetchData`) but
+ * talks to the e2e stack's Kubo node over its HTTP API. Selected by storage.js
+ * when `LOCAL_IPFS_API_URL` is set. Implemented **dependency-free** (global
+ * `fetch`/`FormData`/`Blob`) so nothing IPFS-related ships in the production/ROFL
+ * image — the provider only loads/initialises on localnet.
+ *
+ * @dev Why this exists: in localnet e2e, `MOCK_AI` stays `true` (deterministic
+ * answers) but storage must be REAL and retrievable, because the dApp hydrates
+ * answer content by fetching the CID from a gateway. The in-memory mock store
+ * kept payloads in-process only, so the dApp's display loop never completed.
+ * Real local IPFS gives both sides a shared, fetchable store with real CIDs.
+ *
+ * Plain IPFS has no tag query, so tag-based lookup (`queryTransactionByTags`)
+ * stays in storage.js's in-memory index (now mapping tags → real CIDs). This
+ * layer only moves bytes.
+ */
+
+let apiUrl = null;
+
+function ensureInitialized() {
+  if (!apiUrl) {
+    throw new Error("Local IPFS provider not initialized.");
+  }
+}
+
+/**
+ * @notice Point the provider at a Kubo HTTP API and verify it is reachable.
+ * @param {string} url e.g. "http://localhost:5001"
+ */
+async function initialize(url) {
+  apiUrl = url.replace(/\/+$/, "");
+  // Fail fast with a clear message if Kubo isn't up (the Kubo API is POST-only).
+  const res = await fetch(`${apiUrl}/api/v0/version`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(`Local IPFS (Kubo) not reachable at ${apiUrl} (status ${res.status}).`);
+  }
+  const { Version } = await res.json();
+  console.log(`Local IPFS provider initialized (Kubo ${Version} @ ${apiUrl}).`);
+}
+
+/**
+ * @notice Add data to the local IPFS node and return its CIDv1.
+ * @param {Buffer} dataBuffer The data to store.
+ * @param {Array<{name: string, value: string}>} _tags Unused here — the tag index
+ *        lives in storage.js (plain IPFS has no tag query).
+ * @returns {Promise<string>} The resulting CIDv1.
+ */
+async function uploadData(dataBuffer, _tags = []) {
+  ensureInitialized();
+
+  // cid-version=1 so the dApp can recognise it as an IPFS CIDv1; pin so the
+  // content survives for the run.
+  const form = new FormData();
+  form.append("file", new Blob([dataBuffer]));
+
+  const res = await fetch(`${apiUrl}/api/v0/add?cid-version=1&pin=true`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`IPFS add failed (status ${res.status}): ${await res.text()}`);
+  }
+
+  // Kubo returns newline-delimited JSON; the final line is the added file.
+  const lines = (await res.text()).trim().split("\n").filter(Boolean);
+  const { Hash } = JSON.parse(lines[lines.length - 1]);
+  console.log(`Data uploaded to local IPFS ==> CID: ${Hash}`);
+
+  return Hash;
+}
+
+/**
+ * @notice Fetch data from the local IPFS node by CID.
+ * @param {string} cid The CID of the data to fetch.
+ * @returns {Promise<string>} The raw data as a UTF-8 string (matches the other
+ *          providers, since payloads are AES-GCM ciphertext strings).
+ */
+async function fetchData(cid) {
+  ensureInitialized();
+
+  const res = await fetch(`${apiUrl}/api/v0/cat?arg=${encodeURIComponent(cid)}`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(`IPFS cat failed for ${cid} (status ${res.status}): ${await res.text()}`);
+  }
+
+  const data = await res.text();
+  console.log(`Data fetched from local IPFS. CID: ${cid}, Size: ${data.length} bytes`);
+
+  return data;
+}
+
+module.exports = {
+  initialize,
+  uploadData,
+  fetchData,
+};

--- a/oracle/src/storage/ipfs.js
+++ b/oracle/src/storage/ipfs.js
@@ -32,13 +32,16 @@ function ensureInitialized() {
  * @param {string} url e.g. "http://localhost:5001"
  */
 async function initialize(url) {
-  apiUrl = url.replace(/\/+$/, "");
+  const cleanUrl = url.replace(/\/+$/, "");
   // Fail fast with a clear message if Kubo isn't up (the Kubo API is POST-only).
-  const res = await fetch(`${apiUrl}/api/v0/version`, { method: "POST" });
+  const res = await fetch(`${cleanUrl}/api/v0/version`, { method: "POST" });
   if (!res.ok) {
-    throw new Error(`Local IPFS (Kubo) not reachable at ${apiUrl} (status ${res.status}).`);
+    throw new Error(`Local IPFS (Kubo) not reachable at ${cleanUrl} (status ${res.status}).`);
   }
   const { Version } = await res.json();
+  // Only set after the connectivity check passes, so a failed init leaves the
+  // provider uninitialised and ensureInitialized() still guards later calls.
+  apiUrl = cleanUrl;
   console.log(`Local IPFS provider initialized (Kubo ${Version} @ ${apiUrl}).`);
 }
 
@@ -67,7 +70,13 @@ async function uploadData(dataBuffer, _tags = []) {
 
   // Kubo returns newline-delimited JSON; the final line is the added file.
   const lines = (await res.text()).trim().split("\n").filter(Boolean);
+  if (lines.length === 0) {
+    throw new Error("IPFS add returned an empty response body (expected NDJSON with a Hash).");
+  }
   const { Hash } = JSON.parse(lines[lines.length - 1]);
+  if (!Hash) {
+    throw new Error(`IPFS add response missing Hash field: ${lines[lines.length - 1]}`);
+  }
   console.log(`Data uploaded to local IPFS ==> CID: ${Hash}`);
 
   return Hash;

--- a/oracle/src/storage/storage.js
+++ b/oracle/src/storage/storage.js
@@ -32,6 +32,11 @@ const USE_IN_MEMORY_TAG_INDEX = USE_MOCK_STORAGE || USE_LOCAL_IPFS;
 /**
  * Determines the storage provider based on the CID format.
  * This acts as a router to support multiple storage backends.
+ * NOTE: LOCAL_IPFS mode does NOT use this router — fetchData short-circuits to
+ * ipfs.fetchData before reaching here. So this only distinguishes Autonomys vs
+ * Arweave. The CID-format ordering contract that matters (Autonomys before the
+ * broad IPFS pattern) lives on the consumer side, sense-ai-dapp's
+ * getStorageProvider — keep the two in lockstep.
  * @param {string} cid The Content ID.
  * @returns {object} The appropriate storage utility module.
  */

--- a/oracle/src/storage/storage.js
+++ b/oracle/src/storage/storage.js
@@ -1,5 +1,6 @@
 const arweave = require("./arweave");
 const autonomys = require("./autonomys");
+const ipfs = require("./ipfs");
 const crypto = require("crypto");
 
 // Mock storage in-memory cache (for USE_MOCK_STORAGE mode)
@@ -13,6 +14,18 @@ const mockTagIndex = [];
 
 // --- Mock Flags ---
 const USE_MOCK_STORAGE = process.env.USE_MOCK_STORAGE === "true";
+
+// Local IPFS (Kubo) mode — LOCALNET ONLY. When LOCAL_IPFS_API_URL is set, answer
+// content is stored in / fetched from a real local IPFS node (so the dApp can
+// hydrate it by CID), while tag lookups still use the in-memory index above —
+// plain IPFS has no tag query. MOCK_AI stays true for deterministic answers; only
+// the storage layer becomes real. Never set in production (keeps Kubo out of the
+// TEE path).
+const LOCAL_IPFS_API_URL = process.env.LOCAL_IPFS_API_URL;
+const USE_LOCAL_IPFS = !!LOCAL_IPFS_API_URL;
+
+// Both mock and local-IPFS modes resolve tags via the in-memory index.
+const USE_IN_MEMORY_TAG_INDEX = USE_MOCK_STORAGE || USE_LOCAL_IPFS;
 
 // --- Provider Selection Logic ---
 
@@ -54,6 +67,13 @@ async function initializeStorage() {
     return;
   }
 
+  if (USE_LOCAL_IPFS) {
+    await ipfs.initialize(LOCAL_IPFS_API_URL);
+    console.log("Storage providers initialized (LOCAL IPFS MODE).");
+    mockTagIndex.length = 0;
+    return;
+  }
+
   if (process.env.STORAGE_PROVIDER === "irys") {
     await arweave.initializeIrys();
     console.log("Storage providers initialized (Irys only — STORAGE_PROVIDER=irys).");
@@ -84,6 +104,16 @@ async function uploadData(dataBuffer, tags = []) {
     return mockCid;
   }
 
+  if (USE_LOCAL_IPFS) {
+    // Real CID from the local node; record tags in the in-memory index so
+    // queryTransactionByTags resolves within the run (IPFS has no tag query).
+    const cid = await ipfs.uploadData(dataBuffer, tags);
+    if (Array.isArray(tags) && tags.length > 0) {
+      mockTagIndex.push({ cid, tags });
+    }
+    return cid;
+  }
+
   if (process.env.STORAGE_PROVIDER === "irys") {
     return arweave.uploadData(dataBuffer, tags);
   }
@@ -108,6 +138,10 @@ async function fetchData(cid) {
     return null;
   }
 
+  if (USE_LOCAL_IPFS) {
+    return ipfs.fetchData(cid);
+  }
+
   const provider = getProviderFromCID(cid);
   return provider.fetchData(cid);
 }
@@ -121,19 +155,21 @@ async function fetchData(cid) {
  * @returns {Promise<string|null>} The first matching CID, or null.
  */
 async function queryTransactionByTags(tags) {
-  if (USE_MOCK_STORAGE) {
-    // Return the most recently uploaded CID whose tags satisfy ALL query tags.
+  if (USE_IN_MEMORY_TAG_INDEX) {
+    // Mock and local-IPFS modes resolve tags from the in-memory index (plain IPFS
+    // has no tag query). Return the most recent CID whose tags satisfy ALL query
+    // tags.
     for (let i = mockTagIndex.length - 1; i >= 0; i--) {
       const entry = mockTagIndex[i];
       const matchesAll = tags.every((q) =>
         entry.tags.some((t) => t.name === q.name && t.value === q.value),
       );
       if (matchesAll) {
-        console.log(`[Mock Storage] queryTransactionByTags matched ${entry.cid}`);
+        console.log(`[Tag Index] queryTransactionByTags matched ${entry.cid}`);
         return entry.cid;
       }
     }
-    console.log("[Mock Storage] queryTransactionByTags: no match in mock tag index");
+    console.log("[Tag Index] queryTransactionByTags: no match in in-memory tag index");
     return null;
   }
 

--- a/oracle/src/storage/storage.js
+++ b/oracle/src/storage/storage.js
@@ -139,6 +139,9 @@ async function fetchData(cid) {
   }
 
   if (USE_LOCAL_IPFS) {
+    // Localnet routes EVERY CID to the local node (getProviderFromCID is bypassed):
+    // all CIDs this run were produced by ipfs.uploadData. A stale `mock_…` CID from
+    // a prior USE_MOCK_STORAGE run would 404 here, but each e2e run starts fresh.
     return ipfs.fetchData(cid);
   }
 

--- a/oracle/test/ipfs.test.js
+++ b/oracle/test/ipfs.test.js
@@ -1,0 +1,90 @@
+"use strict";
+
+const chai = require("chai");
+const sinon = require("sinon");
+const { expect } = chai;
+
+const ipfs = require("../src/storage/ipfs");
+
+describe("local IPFS provider (ipfs.js)", function () {
+  afterEach(() => sinon.restore());
+
+  it("initialize verifies connectivity via POST /api/v0/version", async () => {
+    const fetchStub = sinon
+      .stub(global, "fetch")
+      .resolves({ ok: true, json: async () => ({ Version: "0.17.0" }) });
+
+    await ipfs.initialize("http://localhost:5001/"); // trailing slash trimmed
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.firstCall.args[0]).to.equal("http://localhost:5001/api/v0/version");
+    expect(fetchStub.firstCall.args[1]).to.deep.include({ method: "POST" });
+  });
+
+  it("uploadData posts to /api/v0/add (cid-version=1) and returns the CIDv1", async () => {
+    sinon.stub(global, "fetch").callsFake(async (url) => {
+      if (url.endsWith("/api/v0/version")) {
+        return { ok: true, json: async () => ({ Version: "0.17.0" }) };
+      }
+      expect(url).to.contain("/api/v0/add");
+      expect(url).to.contain("cid-version=1");
+      // Kubo returns newline-delimited JSON; last line is the added file.
+      return { ok: true, text: async () => '{"Name":"f","Hash":"bafkreiabc","Size":"9"}\n' };
+    });
+
+    await ipfs.initialize("http://localhost:5001");
+    const cid = await ipfs.uploadData(Buffer.from("ciphertext"), [{ name: "X", value: "1" }]);
+
+    expect(cid).to.equal("bafkreiabc");
+  });
+
+  it("fetchData cats the CID and returns the content as a string", async () => {
+    sinon.stub(global, "fetch").callsFake(async (url) => {
+      if (url.endsWith("/api/v0/version")) {
+        return { ok: true, json: async () => ({ Version: "0.17.0" }) };
+      }
+      expect(url).to.contain("/api/v0/cat?arg=bafkreiabc");
+      return { ok: true, text: async () => "decrypted-elsewhere-ciphertext" };
+    });
+
+    await ipfs.initialize("http://localhost:5001");
+    const data = await ipfs.fetchData("bafkreiabc");
+
+    expect(data).to.equal("decrypted-elsewhere-ciphertext");
+  });
+
+  it("round-trips a payload (add then cat) byte-for-byte", async () => {
+    const payload = "u2FsdGVkX1+abc/def=="; // base64-ish ciphertext string
+    let stored = null;
+    sinon.stub(global, "fetch").callsFake(async (url, opts) => {
+      if (url.endsWith("/api/v0/version")) {
+        return { ok: true, json: async () => ({ Version: "0.17.0" }) };
+      }
+      if (url.includes("/api/v0/add")) {
+        stored = await opts.body.get("file").text();
+        return { ok: true, text: async () => '{"Name":"f","Hash":"bafkreiround","Size":"1"}' };
+      }
+      // cat returns what was stored
+      return { ok: true, text: async () => stored };
+    });
+
+    await ipfs.initialize("http://localhost:5001");
+    const cid = await ipfs.uploadData(Buffer.from(payload), []);
+    const back = await ipfs.fetchData(cid);
+
+    expect(cid).to.equal("bafkreiround");
+    expect(back).to.equal(payload);
+  });
+
+  it("throws a clear error when Kubo is unreachable", async () => {
+    sinon
+      .stub(global, "fetch")
+      .resolves({ ok: false, status: 502, text: async () => "bad gateway" });
+    try {
+      await ipfs.initialize("http://localhost:5001");
+      expect.fail("initialize should have thrown");
+    } catch (e) {
+      expect(e.message).to.contain("not reachable");
+    }
+  });
+});

--- a/oracle/test/ipfs.test.js
+++ b/oracle/test/ipfs.test.js
@@ -1,7 +1,10 @@
 "use strict";
 
 const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
 const sinon = require("sinon");
+
+chai.use(chaiAsPromised.default ?? chaiAsPromised);
 const { expect } = chai;
 
 const ipfs = require("../src/storage/ipfs");
@@ -86,5 +89,24 @@ describe("local IPFS provider (ipfs.js)", function () {
     } catch (e) {
       expect(e.message).to.contain("not reachable");
     }
+  });
+
+  it("uploadData/fetchData throw 'not initialized' before a successful initialize", async () => {
+    // Fresh module instance so apiUrl is null (it persists across tests otherwise).
+    delete require.cache[require.resolve("../src/storage/ipfs")];
+    const freshIpfs = require("../src/storage/ipfs");
+
+    await expect(freshIpfs.uploadData(Buffer.from("x"), [])).to.be.rejectedWith("not initialized");
+    await expect(freshIpfs.fetchData("bafkreiabc")).to.be.rejectedWith("not initialized");
+  });
+
+  it("a failed initialize leaves the provider uninitialized (guard still fires)", async () => {
+    delete require.cache[require.resolve("../src/storage/ipfs")];
+    const freshIpfs = require("../src/storage/ipfs");
+    sinon.stub(global, "fetch").resolves({ ok: false, status: 502, text: async () => "down" });
+
+    await expect(freshIpfs.initialize("http://localhost:5001")).to.be.rejectedWith("not reachable");
+    // apiUrl must NOT have been set by the failed init.
+    await expect(freshIpfs.fetchData("bafkreiabc")).to.be.rejectedWith("not initialized");
   });
 });

--- a/oracle/test/storage.test.js
+++ b/oracle/test/storage.test.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 const chai = require("chai");
 const sinon = require("sinon");
@@ -84,5 +84,68 @@ describe("storage router", function () {
       expect(autonomysStub.queryTransactionByTags.calledOnceWith(tags)).to.be.true;
       expect(txId).to.equal("autonomys_tx_id");
     });
+  });
+});
+
+describe("storage router — local IPFS mode (LOCAL_IPFS_API_URL set)", function () {
+  let storage;
+  let ipfsStub;
+  let arweaveStub;
+  let autonomysStub;
+
+  beforeEach(() => {
+    // The mode flags are read at module load, so set the env before proxyquire.
+    process.env.LOCAL_IPFS_API_URL = "http://localhost:5001";
+
+    ipfsStub = {
+      initialize: sinon.stub().resolves(),
+      uploadData: sinon.stub().resolves("bafkreilocalcid"),
+      fetchData: sinon.stub().resolves("ipfs_data"),
+    };
+    arweaveStub = { initializeIrys: sinon.stub().resolves() };
+    autonomysStub = { initializeAutoDrive: sinon.stub().resolves() };
+
+    storage = proxyquire("../src/storage/storage", {
+      "./ipfs": ipfsStub,
+      "./arweave": arweaveStub,
+      "./autonomys": autonomysStub,
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.LOCAL_IPFS_API_URL;
+    sinon.restore();
+  });
+
+  it("initializeStorage initialises only the local IPFS provider", async () => {
+    await storage.initializeStorage();
+    expect(ipfsStub.initialize.calledOnceWith("http://localhost:5001")).to.be.true;
+    expect(autonomysStub.initializeAutoDrive.called).to.be.false;
+    expect(arweaveStub.initializeIrys.called).to.be.false;
+  });
+
+  it("uploadData routes to IPFS and indexes tags for queryTransactionByTags", async () => {
+    const buffer = Buffer.from("answer payload");
+    const tags = [{ name: "Conversation-Id", value: "1" }];
+
+    const cid = await storage.uploadData(buffer, tags);
+    expect(ipfsStub.uploadData.calledOnceWith(buffer, tags)).to.be.true;
+    expect(cid).to.equal("bafkreilocalcid");
+
+    // The in-memory tag index now resolves the just-uploaded CID (IPFS itself
+    // has no tag query — this is what keeps session-key lookup working).
+    const found = await storage.queryTransactionByTags(tags);
+    expect(found).to.equal("bafkreilocalcid");
+  });
+
+  it("fetchData routes to the local IPFS provider", async () => {
+    const data = await storage.fetchData("bafkreilocalcid");
+    expect(ipfsStub.fetchData.calledOnceWith("bafkreilocalcid")).to.be.true;
+    expect(data).to.equal("ipfs_data");
+  });
+
+  it("queryTransactionByTags returns null when nothing matches", async () => {
+    const found = await storage.queryTransactionByTags([{ name: "Nope", value: "x" }]);
+    expect(found).to.equal(null);
   });
 });


### PR DESCRIPTION
## Summary
Part 1/3 of localnet **answer-content retrieval** (SenseAI e2e). Lets the dApp fetch chat answer content by CID on localnet, so the chat display loop can complete — the in-memory mock store kept payloads in-process only and was unreachable by the dApp.

- **`oracle/src/storage/ipfs.js`** — a dependency-free Kubo HTTP-API provider (global `fetch`/`FormData`/`Blob`), so **nothing IPFS-related ships in the production/ROFL image**. Selected by `storage.js` only when `LOCAL_IPFS_API_URL` is set.
- **`storage.js`** routes `uploadData`/`fetchData` to it, and keeps the **in-memory tag index** for `queryTransactionByTags` (plain IPFS has no tag query — this preserves session-key lookup on follow-up messages).
- **Decouples the two mock concerns:** `MOCK_AI=true` stays (deterministic answers) but storage becomes **real local IPFS**.

Mainnet/testnet (`autonomys`/`arweave`) paths are **unchanged**.

## Test plan
- [x] `bun test` (oracle): storage routing (local-IPFS mode) + `ipfs.js` provider incl. add→cat round-trip — **14 passing**
- [x] Validated live: oracle logs `LOCAL IPFS MODE`, uploads real CIDs, gateway serves them with CORS
- [ ] CI green

## Companion PRs (the loop spans 3 repos)
- `sense-ai-e2e` — Kubo gateway/CORS + env wiring (Phase 2C)
- `sense-ai-dapp` — gateway fetch + cache double-encode fix (Phase 2B)

Tracked under the SenseAI E2E plan ("Phase 2 — Localnet answer-content retrieval").