### PR TITLE
Fix(oracle): gate email alerts to mainnet by default [CU-86d3ba8q1]

### DIFF
--- a/oracle/src/alerting.js
+++ b/oracle/src/alerting.js
@@ -51,11 +51,12 @@ function isEmailAlertingEnabled() {
  * @param {string} message The detailed alert message.
  */
 async function sendEmailAlert(title, message) {
+  // Email is mainnet-only by default (see isEmailAlertingEnabled). Return silently
+  // on non-mainnet rather than logging per call: this path is hit on exactly the
+  // high-frequency noise the gate exists to suppress (reorg/nonce alerts during
+  // e2e/testnet), and the alert itself is already surfaced by the console.error in
+  // sendAlert — so a per-call "skipping" line would just re-flood the logs.
   if (!isEmailAlertingEnabled()) {
-    console.log(
-      `Email alerts disabled for network "${process.env.NETWORK_NAME || "unknown"}" ` +
-        "(mainnet-only; set ALERT_EMAIL_ENABLED=true to override). Skipping email alert.",
-    );
     return;
   }
 

--- a/oracle/src/alerting.js
+++ b/oracle/src/alerting.js
@@ -25,11 +25,40 @@ async function sendSlackAlert(title, message) {
 }
 
 /**
+ * Whether email alerts should fire in the current environment.
+ *
+ * Email alerts land in a human inbox (admin@tradable.app), so they are
+ * MAINNET-ONLY by default — localnet (including e2e) and testnet must never spam
+ * it. `ALERT_EMAIL_ENABLED` is an explicit override: "true" forces email on (e.g.
+ * to test email-alert functionality on a non-mainnet network), "false" forces it
+ * off (e.g. to silence a noisy mainnet incident). Defaulting ON for mainnet —
+ * rather than requiring a flag to be set — means a missing/forgotten flag can
+ * never silently disable production alerting. Slack alerts are unaffected (they go
+ * to a channel, not a personal inbox, and are already env-gated by their tokens).
+ * @returns {boolean}
+ */
+function isEmailAlertingEnabled() {
+  const override = process.env.ALERT_EMAIL_ENABLED;
+  if (override === "true") return true;
+  if (override === "false") return false;
+  const network = process.env.NETWORK_NAME || "";
+  return network === "sapphire" || network === "mainnet" || network.endsWith("-mainnet");
+}
+
+/**
  * Sends a formatted alert email via SendGrid.
  * @param {string} title The title of the alert.
  * @param {string} message The detailed alert message.
  */
 async function sendEmailAlert(title, message) {
+  if (!isEmailAlertingEnabled()) {
+    console.log(
+      `Email alerts disabled for network "${process.env.NETWORK_NAME || "unknown"}" ` +
+        "(mainnet-only; set ALERT_EMAIL_ENABLED=true to override). Skipping email alert.",
+    );
+    return;
+  }
+
   const apiKey = process.env.SEND_GRID_API_KEY;
   const templateId = process.env.SEND_GRID_ALERT_TEMPLATE_ID;
   const fromEmail = process.env.ALERT_FROM_EMAIL;

--- a/oracle/test/alerting.test.js
+++ b/oracle/test/alerting.test.js
@@ -194,6 +194,15 @@ describe("alerting", function () {
       expect(fetchStub.calledOnce).to.be.true;
     });
 
+    it("treats bare 'mainnet' as mainnet for email", async () => {
+      process.env.NETWORK_NAME = "mainnet";
+      setSendGridVars();
+
+      await sendAlert("Prod incident", "needs attention");
+
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
     it("ALERT_EMAIL_ENABLED=true forces email on a non-mainnet network", async () => {
       process.env.NETWORK_NAME = "base-testnet";
       process.env.ALERT_EMAIL_ENABLED = "true";

--- a/oracle/test/alerting.test.js
+++ b/oracle/test/alerting.test.js
@@ -6,8 +6,12 @@ const proxyquire = require("proxyquire");
 describe("alerting", function () {
   let sendAlert;
   let slackStub, fetchStub, consoleErrorStub, consoleWarnStub;
+  let originalNetworkName;
 
   beforeEach(() => {
+    // Capture so we can RESTORE (not delete) — other test files read NETWORK_NAME at
+    // module load via proxyquire, so a global delete here breaks them.
+    originalNetworkName = process.env.NETWORK_NAME;
     // Stub for the Slack WebClient
     slackStub = {
       chat: {
@@ -40,9 +44,20 @@ describe("alerting", function () {
     // Clear environment variables after each test to ensure isolation
     delete process.env.SLACK_ACCESS_TOKEN;
     delete process.env.SEND_GRID_API_KEY;
+    delete process.env.ALERT_EMAIL_ENABLED;
+    // Restore NETWORK_NAME to its pre-test value (other test files depend on it).
+    if (originalNetworkName === undefined) delete process.env.NETWORK_NAME;
+    else process.env.NETWORK_NAME = originalNetworkName;
   });
 
+  // Email alerts are mainnet-only by default (they hit a human inbox); the
+  // SendGrid-dependent tests below enable them explicitly via ALERT_EMAIL_ENABLED.
+  const enableEmail = () => {
+    process.env.ALERT_EMAIL_ENABLED = "true";
+  };
+
   it("should send both Slack and Email alerts when all env vars are set", async () => {
+    enableEmail();
     process.env.SLACK_ACCESS_TOKEN = "fake-slack-token";
     process.env.SLACK_ALERT_CHANNEL = "#fake-channel";
     process.env.SEND_GRID_API_KEY = "fake-sendgrid-key";
@@ -74,6 +89,7 @@ describe("alerting", function () {
   });
 
   it("should only send an email alert if Slack vars are missing", async () => {
+    enableEmail();
     // ONLY set SendGrid vars
     process.env.SEND_GRID_API_KEY = "fake-sendgrid-key";
     process.env.SEND_GRID_ALERT_TEMPLATE_ID = "d-123";
@@ -92,6 +108,9 @@ describe("alerting", function () {
   });
 
   it("should only send a Slack alert if SendGrid vars are missing", async () => {
+    // Enable email so we exercise the SendGrid-vars-missing path (downstream of the
+    // mainnet gate), not the gate's own early return.
+    enableEmail();
     // ONLY set Slack vars
     process.env.SLACK_ACCESS_TOKEN = "fake-slack-token";
     process.env.SLACK_ALERT_CHANNEL = "#fake-channel";
@@ -123,6 +142,7 @@ describe("alerting", function () {
   });
 
   it("should log an error if the email API call fails but not throw", async () => {
+    enableEmail();
     process.env.SEND_GRID_API_KEY = "fake-sendgrid-key";
     process.env.SEND_GRID_ALERT_TEMPLATE_ID = "d-123";
     process.env.ALERT_FROM_EMAIL = "from@test.com";
@@ -136,5 +156,62 @@ describe("alerting", function () {
     // The console.error inside the alerting module should be called
     expect(consoleErrorStub.calledWith("Failed to send email alert:", "SendGrid API is down")).to.be
       .true;
+  });
+
+  // --- Email environment gating (email is mainnet-only by default) ---
+  describe("email environment gating", () => {
+    const setSendGridVars = () => {
+      process.env.SEND_GRID_API_KEY = "fake-sendgrid-key";
+      process.env.SEND_GRID_ALERT_TEMPLATE_ID = "d-123";
+      process.env.ALERT_FROM_EMAIL = "from@test.com";
+      process.env.ALERT_TO_EMAIL = "to@test.com";
+    };
+
+    it("does NOT send email on localnet, even with SendGrid vars set", async () => {
+      process.env.NETWORK_NAME = "base-localnet";
+      setSendGridVars();
+
+      await sendAlert("Reorg", "benign localnet revert");
+
+      expect(fetchStub.called).to.be.false;
+    });
+
+    it("sends email on mainnet by default (no override flag)", async () => {
+      process.env.NETWORK_NAME = "base-mainnet";
+      setSendGridVars();
+
+      await sendAlert("Prod incident", "needs attention");
+
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    it("treats bare 'sapphire' as mainnet for email", async () => {
+      process.env.NETWORK_NAME = "sapphire";
+      setSendGridVars();
+
+      await sendAlert("Prod incident", "needs attention");
+
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    it("ALERT_EMAIL_ENABLED=true forces email on a non-mainnet network", async () => {
+      process.env.NETWORK_NAME = "base-testnet";
+      process.env.ALERT_EMAIL_ENABLED = "true";
+      setSendGridVars();
+
+      await sendAlert("Testing email", "verify the template renders");
+
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    it("ALERT_EMAIL_ENABLED=false suppresses email on mainnet", async () => {
+      process.env.NETWORK_NAME = "base-mainnet";
+      process.env.ALERT_EMAIL_ENABLED = "false";
+      setSendGridVars();
+
+      await sendAlert("Noisy incident", "silenced");
+
+      expect(fetchStub.called).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Summary
The localnet/e2e oracle was emailing **admin@tradable.app** on every alert — chain-reorg notices (benign Hardhat `evm_revert` between e2e tests), nonce noise, etc. `oracle/src/alerting.js` → `sendAlert` fans out to Slack **and** email, and `sendEmailAlert` fired on **any** network whenever the SendGrid env vars were present, with no per-environment gate.

Email alerts hit a human inbox, so this gates them to **mainnet** by default:
- `sendEmailAlert` returns early unless the environment is mainnet (`NETWORK_NAME` is `sapphire` | `mainnet` | ends with `-mainnet`) **or** `ALERT_EMAIL_ENABLED === 'true'` (explicit override to test email-alert functionality on a non-mainnet network). `ALERT_EMAIL_ENABLED === 'false'` force-suppresses (e.g. to silence a noisy mainnet incident).
- **Default-ON for mainnet** (rather than requiring a flag to be set) so a missing/forgotten flag can never silently disable production alerting.
- `console.error`/`log` still fires everywhere (local debugging). **Slack is unaffected** — it posts to a channel, not a personal inbox, and is already env-gated by its tokens. (Gate Slack the same way if localnet Slack-spam is later observed.)

No env-file changes needed: localnet/testnet (including the e2e oracle) are non-mainnet, so email is gated off automatically. Mainnet keeps emailing with no config change.

## Test plan
- [x] Added gating unit tests: localnet off (with SendGrid vars set), mainnet on by default, bare `sapphire` = mainnet, `ALERT_EMAIL_ENABLED=true` forces on for a non-mainnet network, `ALERT_EMAIL_ENABLED=false` suppresses on mainnet.
- [x] Updated the existing SendGrid tests to opt into email (`ALERT_EMAIL_ENABLED=true`) so they still exercise the email path past the gate.
- [x] `afterEach` restores (not deletes) `NETWORK_NAME` so it doesn't leak into other test files that read it at module load.
- [x] `bun test` (oracle) — **157 passing**. `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)