### PR TITLE
Feat(oracle): per-prompt mock delay sentinel for e2e cancel/refund timing [CU-86d3bawhh]

### DIFF
--- a/oracle/src/aiAgentOracle.js
+++ b/oracle/src/aiAgentOracle.js
@@ -61,6 +61,14 @@ const AI_AGENT_CONTRACT_ADDRESS = process.env.AI_AGENT_CONTRACT_ADDRESS;
 const MOCK_AI = process.env.MOCK_AI === "true";
 const USE_MOCK_STORAGE = process.env.USE_MOCK_STORAGE === "true";
 
+// MOCK-mode only: an e2e prompt may embed "__E2E_DELAY_MS__:<n>" to make the mock AI
+// hold its answer for <n> ms, so a test can exercise cancel/refund timing while the
+// prompt is genuinely pending. Honoured ONLY inside queryAIModel's MOCK_AI branch, so
+// it can never affect production (MOCK_AI is false there). Capped so a malformed value
+// can't stall the oracle indefinitely.
+const MOCK_DELAY_SENTINEL = /__E2E_DELAY_MS__:(\d+)/;
+const MAX_MOCK_DELAY_MS = 30000;
+
 // This single function from our utility handles all environment-specific setup.
 let { provider, signer, contract, isSapphire } = initializeOracle(
   NETWORK_NAME,
@@ -736,6 +744,18 @@ async function routeQueryIntent(conversationHistory) {
 }
 
 /**
+ * Parses the optional "__E2E_DELAY_MS__:<n>" marker from a prompt (mock-mode only).
+ * @param {string} text - The latest user message content.
+ * @returns {number} The requested delay in ms (capped at MAX_MOCK_DELAY_MS), or 0.
+ */
+function parseMockDelayMs(text) {
+  if (typeof text !== "string") return 0;
+  const match = text.match(MOCK_DELAY_SENTINEL);
+  if (!match) return 0;
+  return Math.min(Number(match[1]), MAX_MOCK_DELAY_MS);
+}
+
+/**
  * A dispatcher for querying the AI model specified by the routeQueryIntent.
  * @param {Array<object>} conversationHistory - The full conversation history with roles.
  * @param {string} conversationId - The on-chain conversation ID.
@@ -748,6 +768,15 @@ async function queryAIModel(conversationHistory, conversationId, userWallet) {
     const latestUserMessage = conversationHistory
       .filter((msg) => msg.role === "user")
       .pop()?.content || "unknown query";
+
+    // E2E only: honour a "__E2E_DELAY_MS__:<n>" marker in the prompt so a test can
+    // keep the answer pending long enough to cancel/refund it. Mock-only => prod-safe.
+    const delayMs = parseMockDelayMs(latestUserMessage);
+    if (delayMs > 0) {
+      console.log(`[Mock AI] Honouring E2E delay sentinel — holding answer ${delayMs}ms`);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
     const mockResponse = `[MOCK] I acknowledge your query about "${latestUserMessage.substring(0, 40)}...". This is a deterministic mock response for local testing.`;
     console.log("[Mock AI] Returning deterministic mock response");
     return mockResponse;
@@ -1982,6 +2011,7 @@ module.exports = {
   handleBranch,
   handleMetadataUpdate,
   reconstructHistory,
+  parseMockDelayMs,
   getSessionKey,
   encryptSymmetrically,
   decryptSymmetrically,

--- a/oracle/test/aiAgentOracle.test.js
+++ b/oracle/test/aiAgentOracle.test.js
@@ -318,6 +318,30 @@ describe("aiAgentOracle", function () {
     });
   });
 
+  describe("parseMockDelayMs (E2E delay sentinel)", () => {
+    // MOCK-mode only: a prompt may carry "__E2E_DELAY_MS__:<n>" so an e2e test can
+    // hold an answer pending long enough to exercise cancel/refund timing. This is
+    // the pure parser; the actual sleep is wired into queryAIModel's MOCK_AI branch.
+    it("extracts the millisecond value from a sentinel embedded in a prompt", () => {
+      expect(aiAgentOracle.parseMockDelayMs("What is BTC doing? __E2E_DELAY_MS__:8000")).to.equal(
+        8000,
+      );
+    });
+
+    it("returns 0 when no sentinel is present", () => {
+      expect(aiAgentOracle.parseMockDelayMs("a normal prompt")).to.equal(0);
+    });
+
+    it("caps the delay at the maximum to avoid a stuck oracle", () => {
+      expect(aiAgentOracle.parseMockDelayMs("__E2E_DELAY_MS__:999999999")).to.equal(30000);
+    });
+
+    it("returns 0 for non-string input", () => {
+      expect(aiAgentOracle.parseMockDelayMs(undefined)).to.equal(0);
+      expect(aiAgentOracle.parseMockDelayMs(null)).to.equal(0);
+    });
+  });
+
   describe("Oracle Reliability and Startup", () => {
     it("setOracleAddress should do nothing if addresses match", async () => {
       const mockedContract = stubs["./contractUtility"].initializeOracle().contract;


### PR DESCRIPTION
## Why
Part of the e2e coverage-hardening initiative (**CU-86d3bawhh**), Area 2 (cancel concurrency). The mock AI answers instantly, so there's no deterministic window for an e2e test to cancel or refund a prompt while it's *genuinely pending*. This adds a test-only knob so a prompt can be held pending on demand.

## What
A **MOCK-only delay sentinel**: a prompt embedding `__E2E_DELAY_MS__:<n>` makes `queryAIModel`'s `MOCK_AI` branch sleep `<n>` ms (capped at 30s) before returning the deterministic mock answer.

- **Prod-safe by construction** — the delay lives *inside* the `if (MOCK_AI)` branch, and `MOCK_AI` is false in production. No effect on real inference paths.
- **Cancel-correct** — the existing `isJobFinalized` re-check that runs after the answer is generated cleanly drops the answer if the user cancelled during the wait (exactly the flow under test).
- **Covers prompt + regeneration** — both `handlePrompt` and `handleRegeneration` call `queryAIModel`, so both honour the sentinel.
- New pure helper `parseMockDelayMs` (exported) does the parsing; capped so a malformed value can't stall the oracle.

## Test plan
- `bun run test` (oracle): **162 passing** (158 + 4 new `parseMockDelayMs` cases — extract / no-sentinel / cap / non-string), TDD RED→GREEN.
- No app-runtime change outside the mock branch.

[CU-86d3bawhh]